### PR TITLE
Vanessa king patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@ Collection of data reading and data analysis codes from all UBC LAIR STMs
 Sample function commenting format:
 
 % Description
-% what does the function do 
+
+% what does the function do
+
 % Parameters
+
 %%  Input parameters: name(type)
+
 %%  Output parameters: name(type)
+
+function [output] = functionName(input)
+
 ~~~~~~~~~~~function~~~~~~~~~~~~~
 
 
@@ -28,7 +35,7 @@ n : number of points to sample [topoPlaneSub.m]
 offset : vertical offset for each point spectra [gridClickForSpectrum.m]
 xysmooth : the standard deviation of a Gaussian for smoothing xy points (0 is no smoothing) [gridClickForSpectrum.m]
 vsmooth : the standard deviation of a Gaussian for smoothing the voltage sweep points (0 is no smoothing) [gridClickForSpectrum.m]
-grid : grid map (structure) containing x_img, y_img, z_img, x, y, V, and I data [gridLoadDataUpward.m, gridClickForSpectrum.m, gridCorrectionNorm.m]
+grid : grid map (structure) containing x_img, y_img, z_img, x, y, V, and I data [gridLoadDataUpward.m, gridClickForSpectrum.m, gridCorrectionNorm.m, pythonDataToGrid.m]
 norm_didv : 3D matrix with normalized dI/dV data [gridCorrectionNorm.m]
 I_correction : current as a function of voltage corrected to 0 V. [gridCorrectionNorm.m]
 C : normalization parameter [gridCorrectionNorm.m]
@@ -59,3 +66,6 @@ topo : topography 3D matrix [topoPlaneSub.m]
 image : structure, contains topo data. [topoLoadData.m, topoPlaneSub.m]
 didv_masked : masked version of didv [gridAvgMask.m]
 contour : boolean matrix corresponding to bright_indices and dark_indices [gridGetIVThreshold.m, pixelatedContour.m]
+fileName : stringo of full path and file name, including extension. [pythonDataToGrid.m]
+full_3ds : everything within a 3ds file, as read by the nanonispy library [read_grid_data.py]
+gridArrays : 4D array containing the x, y, V, I data of a grid [read_grid_data.py]

--- a/pythonDataToGrid.m
+++ b/pythonDataToGrid.m
@@ -1,8 +1,12 @@
-function grid = pythonDataToGrid(fileName)
-% Reads python processed gridmap data and returns as grid structure
-% Input: fileName = string of full path and 3ds file name, ie: '/Users/vanessa/Desktop/UBC/Lab/Generic_Data_Processing_Code/Grid_Spectroscopy--NbIrPtTe001.3ds'
+% Reads Nanonis python-processed gridmap data and returns as grid structure
+% Parameters 
+%   Input: fileName = string of full path and 3ds file name, ie: '/Users/vanessa/Desktop/UBC/Lab/Generic_Data_Processing_Code/Grid_Spectroscopy--NbIrPtTe001.3ds'
+%   Output: grid = structure containing x, y, V, I gridmap data, same format as output of gridLoadData()
 
-pythonScript_and_fileName = strcat("read_grid_data.py ",fileName);
+
+function grid = pythonDataToGrid(fileName)
+
+pythonScript_and_fileName = strcat("read_grid_data.py ",fileName); % combines the name of python script to run and the filename
 
 python_Data = pyrunfile(pythonScript_and_fileName, "gridArrays"); %Calls pythonScript, gives fileName as input, gets gridArrays as output
 

--- a/pythonDataToGrid.m
+++ b/pythonDataToGrid.m
@@ -1,0 +1,29 @@
+function grid = pythonDataToGrid(fileName)
+% Reads python processed gridmap data and returns as grid structure
+% Input: fileName = string of full path and 3ds file name, ie: '/Users/vanessa/Desktop/UBC/Lab/Generic_Data_Processing_Code/Grid_Spectroscopy--NbIrPtTe001.3ds'
+
+pythonScript_and_fileName = strcat("read_grid_data.py ",fileName);
+
+python_Data = pyrunfile(pythonScript_and_fileName, "gridArrays"); %Calls pythonScript, gives fileName as input, gets gridArrays as output
+
+python_Data_cell = cell(python_Data); %Turning from python List to cell array that contains python arrays
+
+
+x = double(python_Data_cell{1}); %python array -> double array. Shape (num_x, num_y)
+x = x(1,:);%We only require one row, (num_x, num_y) -> (num_x,1)
+grid.x = transpose(x); %(1, num_x) -> (num_x, 1)
+
+
+y = double(python_Data_cell{2}); %python array -> double array. Shape (num_x, num_y)
+grid.y = y(:,1); %We only require one column, (num_x,num_y) -> (1, num_y)
+
+
+V = double(python_Data_cell{3}); %python array -> double array. Shape (1, num_V)
+grid.V = transpose(V); %(1, num_V) -> (num_V, 1)
+
+
+I = double(python_Data_cell{4}); %python array -> double array. Shape (num_x, num_y, num_V)
+I = I * 1e-9; %Transforming back to original values
+grid.I = permute(I, [3,1,2]); %to match matrix data orientation (num_x, num_y, num_V) -> (num_V, num_x, num_y)
+
+end

--- a/pythonDataToGrid.m
+++ b/pythonDataToGrid.m
@@ -1,4 +1,9 @@
-% Reads Nanonis python-processed gridmap data and returns as grid structure
+% Requirements:
+% Matlab 2021B or newer - 'pyrunfile' does not exist in older versions
+% python 3.8 or 3.9. Type 'pyenv' in Matlab to see which python version Matlab recognizes
+
+% Description:
+%  Reads Nanonis python-processed gridmap data and returns as grid structure
 % Parameters 
 %   Input: fileName = string of full path and 3ds file name, ie: '/Users/vanessa/Desktop/UBC/Lab/Generic_Data_Processing_Code/Grid_Spectroscopy--NbIrPtTe001.3ds'
 %   Output: grid = structure containing x, y, V, I gridmap data, same format as output of gridLoadData()

--- a/pythonDataToGrid.m
+++ b/pythonDataToGrid.m
@@ -6,6 +6,7 @@
 %  Reads Nanonis python-processed gridmap data and returns as grid structure
 % Parameters 
 %   Input: fileName = string of full path and 3ds file name, ie: '/Users/vanessa/Desktop/UBC/Lab/Generic_Data_Processing_Code/Grid_Spectroscopy--NbIrPtTe001.3ds'
+%             *Note: because this file is being read in a python script, the filename MUST NOT have spaces
 %   Output: grid = structure containing x, y, V, I gridmap data, same format as output of gridLoadData()
 
 

--- a/read_grid_data.py
+++ b/read_grid_data.py
@@ -1,7 +1,23 @@
-#If first use, do the following in a new terminal window (currently written for zsh):
+#Requirements:
+# - Python 3.8 or 3.9 : so that Matlab can run this file on your behalf
+# - Git
+
+#If first time using, do the following:
+#For Mac: In a new terminal window (zsh):
 #1. type "git clone https://github.com/underchemist/nanonispy.git"
 #2. change your folder using "cd currentfolder/nanonispy" where 'currentfolder' is your current folder path
 #3. type "python setup.py install"
+#For windows on Git Bash:
+#1. type "git clone https://github.com/underchemist/nanonispy.git"
+#2. change your folder using "cd currentfolder/nanonispy" where 'currentfolder' is your current folder path
+#3. type "python setup.py install"
+
+#Description:
+#A python script (not a function) that reads a Nanonis 3ds gridmap file using the nanonispy library.
+#Provides the same unit conversions of x, y data as gridLoadData() for consistency.
+#Parameters:
+# Input:
+# Output:
 
 
 import sys

--- a/read_grid_data.py
+++ b/read_grid_data.py
@@ -16,40 +16,39 @@
 #A python script (not a function) that reads a Nanonis 3ds gridmap file using the nanonispy library.
 #Provides the same unit conversions of x, y data as gridLoadData() for consistency.
 #Parameters:
-# Input:
-# Output:
+# full_3ds : everything within a 3ds file
 
 
 import sys
 import numpy as np
 import nanonispy as nap
 
-grid = nap.read.Grid(sys.argv[1])
-# grid contains everything in the .3ds file
+full_3ds = nap.read.Grid(sys.argv[1])
+# full_3ds contains everything in the .3ds file
 # sys.argv[1] takes the first command-line input. Used to get input from MATLAB
 
 
-#print("This file has the following channels: ",grid.header['channels'])
+#print("This file has the following channels: ",full_3ds.header['channels'])
 
-#print("This file has the following parameters: ",grid.header['experimental_parameters'])
+#print("This file has the following parameters: ", full_3ds.header['experimental_parameters'])
 
 #-------Treatment of grid data-------
 
 #X(m) experimental parameter, shape (num_x, num_y)
-x = grid.signals['params'][:, :, 2]
+x = full_3ds.signals['params'][:, :, 2]
 #Convert from m to nm
 x = x*1e9
 
 #Y(m) experimental parameter, shape (num_x, num_y)
-y = grid.signals['params'][:, :, 3]
+y = full_3ds.signals['params'][:, :, 3]
 #Convert from m to nm
 y = y*1e9
 
 #V values of grid map, shape (num_V)
-V = grid.signals['sweep_signal']
+V = full_3ds.signals['sweep_signal']
 
 #Current (A) fwd, shape (num_x, num_y, num_V)
-I = grid.signals[grid.header['channels'][0]]
+I = full_3ds.signals[full_3ds.header['channels'][0]]
 I = I*1e9 #Not a unit conversion, but necessary for transfer into MATLAB due to memory issues.
 
 gridArrays = [x, y, V, I]

--- a/read_grid_data.py
+++ b/read_grid_data.py
@@ -1,0 +1,40 @@
+#If first use, do the following in a new terminal window (currently written for zsh):
+#1. type "git clone https://github.com/underchemist/nanonispy.git"
+#2. change your folder using "cd currentfolder/nanonispy" where 'currentfolder' is your current folder path
+#3. type "python setup.py install"
+
+
+import sys
+import numpy as np
+import nanonispy as nap
+
+grid = nap.read.Grid(sys.argv[1])
+# grid contains everything in the .3ds file
+# sys.argv[1] takes the first command-line input. Used to get input from MATLAB
+
+
+#print("This file has the following channels: ",grid.header['channels'])
+
+#print("This file has the following parameters: ",grid.header['experimental_parameters'])
+
+#-------Treatment of grid data-------
+
+#X(m) experimental parameter, shape (num_x, num_y)
+x = grid.signals['params'][:, :, 2]
+#Convert from m to nm
+x = x*1e9
+
+#Y(m) experimental parameter, shape (num_x, num_y)
+y = grid.signals['params'][:, :, 3]
+#Convert from m to nm
+y = y*1e9
+
+#V values of grid map, shape (num_V)
+V = grid.signals['sweep_signal']
+
+#Current (A) fwd, shape (num_x, num_y, num_V)
+I = grid.signals[grid.header['channels'][0]]
+I = I*1e9 #Not a unit conversion, but necessary for transfer into MATLAB due to memory issues.
+
+gridArrays = [x, y, V, I]
+


### PR DESCRIPTION
A ~vanessa made~ Nanonis data processing method. The goal was to write code to extract grid data from 3ds files in a format such that it could be processed with the code previously used to process Matrix data that the Omicron folks are more familiar with. 

The code replaces ‘gridLoadDataUpward.m’ and ‘gridLoadDataDownward.m’ which were made for Matrix-style data. As of the May 3, 2022 iteration, these scripts cannot extract topology data, though this can be updated in the future.

The files involved:

read_grid_data.py

pythonDataToGrid.m

Nanonis_Processing_Test.m (this serves as an example of how to use the code, its not necessary)

They can all be found under C:\Users\lairadmin\Documents\MATLAB\customscripts\Vanessa_test\

**How to Use:**

Assumptions:

you want to process a 3ds file and process it using the matlab functions previously made for Matrix-style data

you are on the Omicron computer (formerly called the spectrometer computer),

OR you are on a different computer and:

you have Matlab 2021B or later

you have python 3.8 or 3.9 and Matlab can access it on its path (see ‘pyenv’ to test if this is true)

you have cloned the nanonispy github repository (see comment at top of read_grid_data.py for access & instructions)

Usage:

Open up Nanonis_Processing_Test.m. This is an example of how you would use the scripts. 

folder = a string containing the full path to the folder containing your 3ds file. Note, it should end with a ‘\’

file = a string containing the 3ds file name, including the ‘.3ds’ extension. NOTE: file names CANNOT have a space in them. This raises an error in Python. I suggest replacing spaces with ‘_‘.

Then, the next line will call the function ‘pythonDataToGrid.m’ for that 3ds file. The output of the function is:

grid = a 1x1 structure variable containing data for x, y, V, and I. It is the same formatting as the ‘grid’ (sometimes called ‘grd’) structure used in the Matrix-style functions.* For example, if you wanted plug this in to the NbIrTe4 processing code, this would fully replace everything before gridCorrNorm.

* the grid structure contains grid.x, grid.y, grid.V, grid.I, some older versions of our custom scripts ask for ‘grid.iv’. You should update those scripts to ask for grid.I to be consistent with our naming scheme.

** gridClickForSpectrum allows you to input grid as an optional 8th input. This was made so that gridClickForSpectrum could use the topo data instead of the grid spatial data. However, (as of May 3, 2022) this Nanonis processing code does NOT contain the topo data. So trying to use grid as the 8th input will cause an error because. Instead, just don’t provide an 8th input.