### PR TITLE
Ma dev mask inv logic

### DIFF
--- a/functions/selecting/MaskSparse3DGrid.m
+++ b/functions/selecting/MaskSparse3DGrid.m
@@ -56,5 +56,5 @@ else
     disp("Data size parsed is not 3D.")
     return
 end
-
+mask = logical(mask); %set datatype
 end

--- a/functions/selecting/MaskSparseGrid.m
+++ b/functions/selecting/MaskSparseGrid.m
@@ -48,5 +48,5 @@ else
     disp("Data size parsed is not 2D.")
     return
 end
-
+mask = logical(mask); %set datatype
 end

--- a/functions/selecting/gridMaskLine.m
+++ b/functions/selecting/gridMaskLine.m
@@ -70,5 +70,5 @@ mapshow(BoundaryPoints_x,BoundaryPoints_y,'DisplayType','point','Marker','o')
 
 % make the mask 
 [mask,~] =createLineSegmentMask(size(topo), BoundaryPoint1, BoundaryPoint2);
-
+mask = logical(mask); %set datatype
 end

--- a/functions/selecting/gridMaskLineSegment.m
+++ b/functions/selecting/gridMaskLineSegment.m
@@ -216,6 +216,7 @@ end
 %omitted as the log comments that the function returns are assigned above
 %based on the use case
 [mask,~] =createLineMask(size(topo), startPoint,endPoint);
+mask = logical(mask); %set datatype
 
 
 end

--- a/functions/selecting/invertMask.m
+++ b/functions/selecting/invertMask.m
@@ -1,7 +1,7 @@
 function [mask, comment] = invertMask(mask)
 %Inverts mask
 %   If any element of mask is >1 the mask is renormalized to the interval
-%   [0,1]. The (normalized) mask is inverted by applying abs(x-1). 
+%   [0, max] -> [0,1]. The (normalized) mask is inverted by applying abs(x-1). 
 
 % M. Altthaler, March 2024
 
@@ -11,12 +11,18 @@ end
 
 comment = "invertMask(mask)";
 
+
+
 if ismatrix(mask)
+    tf = islogical(mask);
     if ~isempty(find(mask))
         %check if the mask has nonzero elements
         mask = abs(mask./max([max(mask(:)),1])-1); %norm masks exceeding 1 to [0,1] and invert
     else %div 0 exception for an all zero mask - invert 0->1
         mask = abs(mask-1);
+    end
+    if tf==1 %parsed mask was logical
+        mask = logical(mask); %reassign logical datatype
     end
 end
 

--- a/functions/selecting/invertMask.m
+++ b/functions/selecting/invertMask.m
@@ -1,0 +1,23 @@
+function [mask, comment] = invertMask(mask)
+%Inverts mask
+%   If any element of mask is >1 the mask is renormalized to the interval
+%   [0,1]. The (normalized) mask is inverted by applying abs(x-1). 
+
+% M. Altthaler, March 2024
+
+arguments
+    mask    {mustBeNumericOrLogical,mustBeNonnegative}
+end
+
+comment = "invertMask(mask)";
+
+if ismatrix(mask)
+    if ~isempty(find(mask))
+        %check if the mask has nonzero elements
+        mask = abs(mask./max([max(mask(:)),1])-1); %norm masks exceeding 1 to [0,1] and invert
+    else %div 0 exception for an all zero mask - invert 0->1
+        mask = abs(mask-1);
+    end
+end
+
+end

--- a/functions/selecting/logicANDmask.m
+++ b/functions/selecting/logicANDmask.m
@@ -1,0 +1,20 @@
+function [mask, comment] = logicANDmask(maskA,maskB)
+%Logic AND of two binary masks
+%   Converts masks A and B into logical matrices and returns a mask that
+%   represents a logical AND, i.e. only elements where both masks where 1
+%   are 1
+
+% M. Altthaler, March 2024
+
+arguments
+    maskA   {mustBeNumericOrLogical,mustBeNonnegative}
+    maskB   {mustBeNumericOrLogical,mustBeNonnegative}
+end
+
+comment = "logicANDmask(maskA,maskB)";
+
+if ismatrix(maskA) && ismatrix(maskB)
+    mask = logical(maskA).*logical(maskB);
+end
+
+end

--- a/functions/selecting/logicANDmask.m
+++ b/functions/selecting/logicANDmask.m
@@ -13,8 +13,9 @@ end
 
 comment = "logicANDmask(maskA,maskB)";
 
-if ismatrix(maskA) && ismatrix(maskB)
+if ismatrix(maskA) && ismatrix(maskB) && size(maskA,1) == size(maskB,1) && size(maskA,2) == size(maskB,2)
     mask = logical(maskA).*logical(maskB);
+    mask = logical(mask); %convert to logical datatype
 end
 
 end

--- a/functions/selecting/logicORmask.m
+++ b/functions/selecting/logicORmask.m
@@ -1,8 +1,8 @@
 function [mask, comment] = logicORmask(maskA,maskB)
 %Logic OR of two binary masks
-%   Converts masks A and B into logical matrices and returns a mask that
-%   represents a logical OR, i.e. every elements where any of the two masks 
-%   is 1 is also 1.
+%   Adds masks A and B and converts the sum into a logical maks. The 
+%   returend  mask represents a logical OR, i.e. every elements where any 
+%   of the two masks is 1 is also 1.
 
 % M. Altthaler, March 2024
 
@@ -13,7 +13,7 @@ end
 
 comment = "logicANDmask(maskA,maskB)";
 
-if ismatrix(maskA) && ismatrix(maskB)
+if ismatrix(maskA) && ismatrix(maskB) && size(maskA,1) == size(maskB,1) && size(maskA,2) == size(maskB,2)
     mask = logical(maskA+maskB); %all non zero elements are converted to 1's 
 end
 

--- a/functions/selecting/logicORmask.m
+++ b/functions/selecting/logicORmask.m
@@ -1,0 +1,20 @@
+function [mask, comment] = logicORmask(maskA,maskB)
+%Logic OR of two binary masks
+%   Converts masks A and B into logical matrices and returns a mask that
+%   represents a logical OR, i.e. every elements where any of the two masks 
+%   is 1 is also 1.
+
+% M. Altthaler, March 2024
+
+arguments
+    maskA   {mustBeNumericOrLogical,mustBeNonnegative}
+    maskB   {mustBeNumericOrLogical,mustBeNonnegative}
+end
+
+comment = "logicANDmask(maskA,maskB)";
+
+if ismatrix(maskA) && ismatrix(maskB)
+    mask = logical(maskA+maskB); %all non zero elements are converted to 1's 
+end
+
+end


### PR DESCRIPTION
- ensures all mask functions (except gridMaskPoint()) return logical masks (i.e. the proper datatype) 
- added invertMask(mask), inverts a mask, i.e. 0->1 and 1->0. This also works on nonbinary masks, i.e. 0.2->0.8, 0.5->0.5. If elements of the mask exceed 1 they are normalized [0,max] -> [0,1] and then inverted. If a (datatype) logical mask is parsed it will be returned as such. Otherwise a datatype double mask is returned. 
- added logicORmask(maskA,maskB), checks if maskA and maskB are matrices of matching dimensions adds them and converts the output to a logical mask. Here every element that is 1 in either of the masks is a 1 in the output (i.e. logical OR operation)
- added logicANDmask(maskA,maskB), checks if maskA and maskB are matrices of matching dimensions and converts them to logical matrices. These are then elementwise multiplied and the output is a logical mask. Here only elements that are 1's in both masks are returned as 1s (i.e. logical AND operation). 

These functions allow us to combine mask of different regions, e.g. logicalORmask() can be used to combine to ROIs or exclude them if invertMask() is applied. logicalANDmask can be used to combine the selection of an ROI with a sparse grid mask.