### PR TITLE
Change to how topo is loaded, including orientation transformations

### DIFF
--- a/functions/loading/loadData.m
+++ b/functions/loading/loadData.m
@@ -1,4 +1,4 @@
-function [data, commentA, commentB, commentC, commentD] = loadData(data, direction)
+function [data, commentA, commentB, commentC, commentD] = loadData(data)
 %Load STM data from UI selected file of variable formats (.3ds, .sxm,) 
 %   Select data file using the UI. Basen on the file extension the 
 %   appropriate specific loading function for that dataype is chosen. 
@@ -8,13 +8,8 @@ function [data, commentA, commentB, commentC, commentD] = loadData(data, directi
 %   Requires the toplevel data struct variable to be parsed. In this case 
 %   the function adds the field data.<name> to it. 
 
-%   Optional arguments (to be expanded)
-%   direction   is an optional input to specify the direcion 'forward' or
-%               'backward' a topo image (.sxm) is loaded
-
 arguments
     data        
-    direction   {mustBeText}="forward"
 end
 
 %select data via UI
@@ -45,7 +40,7 @@ switch fileExt
         data.(fieldName) = grid;
     case '.sxm'
         %load smx file -> Nanonis topo
-        [topo, commentC] = load_topo_Nanonis(filePath, fullFileName, direction);
+        [topo, commentC] = load_topo_Nanonis(filePath, fullFileName);
         data.(fieldName)= topo;
     case '.dat'
         %load dat file -> Nanonis point spectrum
@@ -60,7 +55,7 @@ end
 data.(fieldName).dataSetName = fieldName;
 
 %log function call
-commentA = sprintf("[data.%s, ...] = loadData(data,direction = %s); Selected data: <path>/<file>", fieldName, direction);
+commentA = sprintf("[data.%s, ...] = loadData(data); Selected data: <path>/<file>", fieldName);
 
 %log selected file
 commentB = sprintf("%s/%s", filePath, fullFileName);

--- a/functions/loading/sxmPermute.m
+++ b/functions/loading/sxmPermute.m
@@ -1,0 +1,34 @@
+function [permuted_forward,permuted_backward] = sxmPermute(channel_forward, channel_backward, scan_direction)
+%Permutation operation for all channels in a 'sxm' file
+%   Permutes a channel from a sxm file so that its orientation matches what
+%   we see as a user in Nanonis.
+% Input: 
+%   channel_forward: array, channel variable in the forward scan direction
+%   channel_backward: array, channel variable in the backward scan direction
+%   scan_direction: string, whether the scan was made 'Up' or 'Down'
+% Output: 
+%   permuted_forward: array, the forward variable permuted
+%   permuted_backward: array, the backward variable permuted
+
+
+arguments
+    channel_forward
+    channel_backward 
+    scan_direction      {mustBeText}
+end
+
+
+%no transformation necessary for UP-FORWARD
+permuted_forward = channel_forward;
+
+%transformation for UP-BACKWARD
+permuted_backward = flip(channel_backward,1);
+
+if scan_direction == "down"
+    %transformation for DOWN-FORWARD
+    permuted_forward = flip(permuted_forward,2);
+    %transformation for DOWN-BACKWARD
+    permuted_backward = flip(permuted_backward,2);
+end
+
+end


### PR DESCRIPTION
Update to how topo is loaded, particularly loading all channels (including forward and backward of each).

Orientation transformation for all possible topo types (ie: Up vs Down, Forward vs Backward, Complete vs Partial, Square vs Rectangle)

Despite our issues with plotting, I have checked that all topos are loading in the correct orientation by these functions 