### PR TITLE
Modificaitons to VS02A block, and two functions (including renaming one of them by dropping the prefix 'grid'

### DIFF
--- a/executable_script/mainTrunk.m
+++ b/executable_script/mainTrunk.m
@@ -366,7 +366,7 @@ clearvars dataset variableIn1 variableOut1
 
 %presets:
 dataset = 'grid';           % specify the dataset to be used: e.g. grid
-variableIn1 = 'I_smoothed'; % specify the variable to be processed, e.g. I, or I_backward
+variableIn1 = 'I'; % specify the variable to be processed, e.g. I, or I_backward
                             % this is a 3d array form (x, y, V)
 variableIn2 = 'V';          % specify the variable to be processed, e.g. V or Z
                             % this is a 1d array form (V, 1)
@@ -629,47 +629,52 @@ end
 % Clear preset variables
 clearvars dataset variableIn1 variableIn2 variableIn3 savefigpath plot_name_1 plot_name_2 LayoutCase;
 %% VS02A Visualize-Spectrum-02-A; allows you to click on a grid/topo and plot the spectra
-% Edited by: M. Altthaler June 2024 ,Vanessa October 2023
+% Edited by: James Day January 2025, M. Altthaler June 2024, Vanessa October 2023
 % This section of the code opens a GUI that allows you to click
 % point(s) on a grid and plot the spectra
 %
 % NOTE: plots dIdV(V) curves. But requires matching V (V_redeuced) as voltage axis input.
 
-%presets:
-dataset ='grid';                %specify the dataset to be used: e.g. grid
-variableIn1 = 'dIdV';           %specify the variable data(x,y,V) a V slice is taken from: e.g. didv
-variableIn2 = 'V_reduced';      %specify the variable to be processed as the V axis: e.g. V_reduced
-
-imageV = 0.6;                   %specify the voltage of the dIdV slice to be displayed [float]
-n=2;                            %Number of point spectra to be selected for the plot [integer]
-offset=0;                       %Vertical offset for each point spectra 
+% Presets:
+dataset = 'grid';                % specify the dataset to be used: e.g., grid
+variableIn1 = 'dIdV';            % specify the variable data(x, y, V) a V slice is taken from: e.g., didv
+variableIn2 = 'V_reduced';       % specify the variable to be processed as the V axis: e.g., V_reduced
+imageV = 0.25;                    % specify the voltage of the dI/dV slice to be displayed
+offset = 0;                      % vertical offset for each point spectrum
+n = 3;                           % number of points to be selected for the plot (can exit early by pressing Enter)
 
 %%%%%%%%%%%%%%%%%% DO NOT EDIT BELOW %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%LOG data in/out:
-LOGcomment = sprintf("<dataset>.<variableIn1>: %s.%s; <dataset>.<variableIn2>: %s.%s; ",dataset ,variableIn1 ,dataset ,variableIn2);
-LOGcomment = logUsedBlocks(LOGpath, LOGfile, "VS02A", LOGcomment ,0);
+% LOG data in/out:
+LOGcomment = sprintf("DataIn: dataset = %s, variableIn1 = %s, variableIn2 = %s", dataset, variableIn1, variableIn2);
+LOGcomment = logUsedBlocks(LOGpath, LOGfile, "VS02A", LOGcomment, 0);
 
-%execute function FUNCTION OUTDATED???
-LOGcomment = gridClickForSpectrum(data.(dataset).(variableIn1), data.(dataset).(variableIn2), imageV, offset, n);
-%LOG function call
-LOGcomment = logUsedBlocks(LOGpath, LOGfile, "VS02A", LOGcomment ,0);
+% Execute the `clickForSpectrum` function
+try
+    LOGcomment = clickForSpectrum(data.(dataset).(variableIn1), data.(dataset).(variableIn2), imageV, offset, n);
+    LOGcomment = logUsedBlocks(LOGpath, LOGfile, "  ^  ", LOGcomment, 0);
+    
+    % Ask for the plot name and the folder to save it in
+    targetFolder = uigetdir([], 'Choose folder to save the figure to:');
+    plot_name = uniqueNamePrompt("clickedSpectrum", "", targetFolder);
+    
+    % LOG saved figure name and dir
+    LOGcomment = sprintf("Figure saved as (<dir>/<plotname>.fig): %s/%s.fig", targetFolder, plot_name);
+    LOGcomment = logUsedBlocks(LOGpath, LOGfile, "  ^  ", LOGcomment, 0);
+    
+    % Save the created figure here
+    savefig(strcat(LOGpath, "/", plot_name, ".fig"));
+    
+    % Create a copy of the log corresponding to the saved figure
+    saveUsedBlocksLog(LOGpath, LOGfile, targetFolder, plot_name);
 
-%ask for plotname and the folder it should be saved in:
-targetFolder = uigetdir([],'Choose folder to save the figure to:');
-plot_name = uniqueNamePrompt("clickedSpectrum","",targetFolder);
-%LOG saved figure name and dir
-LOGcomment = sprintf("Figure saved as (<dir>/<plotname>.fig): %s/%s.fig", targetFolder, plot_name);
-LOGcomment = logUsedBlocks(LOGpath, LOGfile, "  ^  ", LOGcomment ,0);
-
-%save the created figures here:
-savefig(strcat(LOGpath,"/",plot_name,".fig"))
-
-%create copy of the log corresponding to the saved figures
-saveUsedBlocksLog(LOGpath, LOGfile, targetFolder, plot_name);
-
-%clear excess variables that may create issues in other blocks
-clearvars dataset variableIn1 variableIn2 imageV n offset
-clearvars targetFolder plot_name
+    % Clear variables to avoid conflicts
+    clearvars dataset variableIn1 variableIn2 imageV n offset targetFolder plot_name
+catch ME
+    % Handle unexpected errors gracefully
+    disp("An error occurred during point selection or spectrum plotting:");
+    disp(ME.message);
+    disp("Plots will not be saved.");
+end
 %% VS03A Visualize-Spectrum-03-A; circular masking;
 
 % Edited by Jiabin May 2024; Jisun Oct 2023, again in Feb 2024, again in Dec 2024.

--- a/functions/basic/ginputAllPlatform.m
+++ b/functions/basic/ginputAllPlatform.m
@@ -1,79 +1,85 @@
 function pos = ginputAllPlatform(n)
-%GINPUTALLPLATFORM Prompts the user to select points in the current figure window.
-%THIS IS AN EQUIVALENT VERSION OF `GINPUT` BUT SUITS BETTER WITH MORE PLATFORMS
-%   option 1: input number of clicks: n
-%   option 2: click number of points until pressing 'enter key'
+%GINPUTALLPLATFORM Select points from the current figure, compatible across platforms
+% This function allows the user to select points in a figure window.
+% The user can terminate the selection early by pressing Enter.
+%
+% Edited: James Day Jan 2025; Jiabin Yu 2024
+%
+% Arguments:
+%   n: (optional) Number of points to select. If not specified or set to 
+%      'inf', the user can select points until pressing the Enter key.
+%
+% This function is designed to be more platform-agnostic than the default ginput.
+% It continuously waits for either mouse clicks (to record points) or the Enter 
+% key (to finish selecting points early). If the figure is closed unexpectedly, 
+% the loop ends gracefully. If n is specified, once that many points are selected, 
+% the function stops collecting more points.
+%
+% The selected points (x,y) are returned in 'pos', an Nx2 matrix, with each row 
+% containing the coordinates of one selected point. If no points are selected 
+% (e.g., pressing Enter immediately), 'pos' will be empty.
+%
+% The original comments and functionality have been preserved. Additional 
+% comments have been added in the same style to clarify the code flow.
 
-%   pos = GINPUTALLPLATFORM(n)
-%   pos returns a n-by-2 array containing the x and y coordinates of the selected points.
-    
-arguments 
-    n   {mustBeNumeric, mustBePositive} = []
-    
+arguments
+    n {mustBeNumeric, mustBePositive, mustBeInteger} = inf
 end
 
-    % Initialize the output array
-    pos = zeros(n, 2);
+pos = [];
+disp("Click points on the figure. Press Enter to abort.");
 
-    % Create a figure if there is no current figure
-    if isempty(gcf)
-        figure;
-    end
-    if  ~isempty(n)
-        % Loop to capture N points
-        for i = 1:n
-            % Display instructions
-            disp(['Select point ', num2str(i), ' of ', num2str(n), ' in the figure window.']);
-    
-            % Wait for a mouse button press
-            w=waitforbuttonpress;
-            % Get the coordinates of the current point
-            currentPoint = get(gca, 'CurrentPoint');
+% If no figure is currently open, create a new one. This ensures the user
+% always has a figure to click on.
+if isempty(gcf)
+    figure;
+end
 
-            % Check if the button press is a key press
-            if w == 1
-                % Get the key that was pressed
-                key = get(gcf, 'CurrentCharacter');
-                
-                % Check if the key is the Enter key (ASCII code 13)
-                if double(key) == 13
-                    % If Enter key was pressed, terminate the loop
-                    pos=pos(1:i-1,:);
-                    break;
-                end
-            end
+% Get the current axes handle and ensure that new points remain plotted.
+ax = gca;
+hold(ax, 'on');
 
-            pos(i, :) = currentPoint(1, 1:2);
-        end
-    else
-        disp('please click the points on the graph; or exit clicking by pressing the enter key /')
-       
-    % Start the while loop
-        while isempty(n)
-            % Wait for a button press
-            w = waitforbuttonpress;
-            % Get the current point if a mouse click happened
-            currentPoint = get(gca, 'CurrentPoint');
-            % Check if the button press is a key press
-            if w == 1
-                % Get the key that was pressed
-                key = get(gcf, 'CurrentCharacter');
-                
-                % Check if the key is the Enter key (ASCII code 13)
-                if double(key) == 13
-                    % If Enter key was pressed, terminate the loop
-                    break;
-                end
-            else
-        
-                % Append the current point to the position array
-                % pos = [pos; currentPoint];
-                pos = [pos; currentPoint(1, 1:2)];
-            end
-        end
-        
+% Main loop to capture user input events (mouse clicks or key presses).
+while true
+    try
+        w = waitforbuttonpress; % Wait for a button press (mouse or keyboard)
+    catch
+        % If the figure is closed while waiting, exit gracefully.
+        disp("Figure closed. Exiting point selection.");
+        break;
     end
 
+    if w == 0
+        % w == 0 indicates a mouse click event, so record the clicked point.
+        currentPoint = get(ax, 'CurrentPoint');
+        % Append the newly selected point (x,y) to the pos array.
+        pos = [pos; currentPoint(1, 1:2)];
 
+        % If a finite number of points n is specified and reached, stop collecting.
+        if size(pos, 1) >= n
+            break;
+        end
+    elseif w == 1
+        % w == 1 indicates a key press event.
+        key = get(gcf, 'CurrentCharacter');
+        % If Enter (ASCII 13) is pressed or no character is retrieved (empty),
+        % terminate point selection early.
+        if isempty(key) || double(key) == 13
+            disp("Point selection terminated early by pressing Enter.");
+            break;
+        else
+            % Any other key press is invalid for this action. Instruct the user
+            % on proper usage.
+            disp("Invalid key press. Use mouse clicks to select points or press Enter to finish.");
+        end
+    end
+end
 
+% After the loop, report the selected points, if any.
+if ~isempty(pos)
+    disp("Selected points:");
+    disp(pos);
+else
+    disp("No points selected.");
+end
 end

--- a/functions/visualization/clickForSpectrum.m
+++ b/functions/visualization/clickForSpectrum.m
@@ -1,0 +1,142 @@
+function [comment] = clickForSpectrum(didv, V_reduced, imageV, offset, n, pointsList)
+% CLICKFORSPECTRUM Select points and plot spectra
+%Creates a GUI window where you can select a point(s), then it plots the spectra from that point(s). 
+%   Plots a 2D slice of the didv data at the closest value of V_reduced to 
+%   the set value imageV. From this figure up to n points can be selected 
+%   by clicking on the 2D image. For the selected points the spectra didv(V) 
+%   are plotted. 
+%
+% Edited: James Day Jan 2025; M. Altthaler 05/2024; Vanessa 2023
+%
+%   OPT TBD:    make function accept a list of point coordinates to be
+%               plotted. This feature is untested! (05/2024)
+%
+% Arguments:
+%   didv, V_reduced, imageV, offset, n, pointsList as before
+%
+% This function plots a 2D slice of the dI/dV data (didv) at a specified 
+% bias voltage (imageV). The user can select up to n points on this 2D 
+% slice, and for each selected point, the corresponding dI/dV spectrum is 
+% plotted. The function returns a log comment string containing the 
+% coordinates of the selected points.
+%
+% No code modifications have been made, only additional comments have been added.
+% The original commenting style and content are preserved as much as possible.
+% Additional comments are provided below in a similar style to clarify the 
+% functionality and flow of the code.
+%
+% Note: 
+% - The argument 'pointsList' can be used to provide predetermined points 
+%   instead of interacting with the figure.
+% - If the user presses Enter early or clicks outside the image boundaries, 
+%   the code handles these scenarios gracefully.
+% - Colors for each point are chosen from a predefined set, cycling through 
+%   'rgbcmyk'.
+
+arguments
+    didv        {mustBeNumeric}          % 3D array (x,y,V) with dI/dV data
+    V_reduced   {mustBeVector}           % Vector of reduced bias voltages
+    imageV      {mustBeNumeric}          % Chosen bias voltage for slice display
+    offset      {mustBeNumeric} = 0      % Vertical offset between spectra
+    n           {mustBePositive, mustBeInteger} = 2  % Number of points to select
+    pointsList  {mustBeNumeric} = []     % Optional predefined list of points (x,y)
+end
+
+% Prepare log comment with input parameters
+comment = sprintf("DataIn: dataset = grid, variableIn1 = dIdV, variableIn2 = V_reduced; clickForSpectrum(imageV=%.2f, offset=%.2f, n=%d) | ", imageV, offset, n);
+
+% Determine which slice of didv to plot by finding the closest voltage to imageV
+[~, imN] = min(abs(V_reduced - imageV)); 
+fig_plot = didv(:, :, imN);  % Extract the 2D slice at the chosen voltage
+
+% Create a new figure to display the 2D slice as an image
+fig_name = ['dI/dV slice at ', num2str(imageV), ' V'];
+img = figure('Name', fig_name);
+imagesc(fig_plot); colormap('gray'); hold on;
+axis xy; axis image;  % Set axes to normal orientation and equal scaling
+title(fig_name);      % Title reflects the chosen bias voltage
+
+% Create a separate figure for the spectra at selected points
+spec = figure('Name', 'dI/dV at selected points'); hold on;
+xlabel('Bias [V]'); ylabel('dI/dV (a.u.)'); % Label axes for clarity
+
+% Define the radius and coordinates for drawing circles on the image
+radius = 2;
+xx = -radius:0.01:radius;
+yy = sqrt(radius^2 - xx.^2);
+
+% Define a set of colors to differentiate multiple selected points
+colours = 'rgbcmyk';
+
+% If no predefined points are given, interactively select them
+if isempty(pointsList)
+    % Initialize the pointsList array
+    pointsList = zeros(n, 2);
+    for k = 1:n
+        figure(img);
+        disp(['Select point ', num2str(k), ' of ', num2str(n), ' in the figure window.']);
+        
+        % Attempt to get a point from user clicks
+        try
+            position = round(ginputAllPlatform(1));
+        catch
+            % If Enter is pressed early, trim pointsList accordingly
+            pointsList = pointsList(1:k-1, :);
+            break;
+        end
+
+        % Validate that the selected point is within the data range
+        if position(1) < 1 || position(2) < 1 || ...
+           position(1) > size(didv, 1) || position(2) > size(didv, 2)
+            disp("Invalid point selected, please click within the image.");
+            continue; % Skip invalid point and prompt again
+        end
+        
+        % Store the valid point
+        pointsList(k, :) = position;
+
+        % Choose a color for this point
+        cidx = mod(k-1, 7) + 1;
+        thisColor = colours(cidx);
+
+        % Draw large circles on the image to highlight the selected area
+        plot(position(1) + xx, position(2) + yy, thisColor, 'LineWidth', 1.5);
+        plot(position(1) + xx, position(2) - yy, thisColor, 'LineWidth', 1.5);
+
+        % Draw a small open circle at the exact selected pixel
+        % This indicates the exact (x,y) coordinate chosen
+        plot(position(1), position(2), 'o', 'MarkerEdgeColor', thisColor, 'MarkerFaceColor', 'none', 'LineWidth', 1.5);
+
+        % Append the chosen point to the log comment
+        comment = strcat(comment, sprintf("(%d,%d), ", position(1), position(2)));
+
+        % Plot the corresponding spectrum in the 'spec' figure
+        % Offset is applied to separate multiple spectra vertically
+        figure(spec);
+        plot(V_reduced, squeeze(didv(position(1), position(2), :)) + (k-1)*offset, thisColor, 'LineWidth', 1.5);
+    end
+else
+    % If pointsList is provided, plot those points without user interaction
+    for k = 1:size(pointsList, 1)
+        position = pointsList(k, :);
+
+        cidx = mod(k-1, 7) + 1;
+        thisColor = colours(cidx);
+
+        figure(img);
+        % Draw large circles to indicate the area of interest
+        plot(position(1) + xx, position(2) + yy, thisColor, 'LineWidth', 1.5);
+        plot(position(1) + xx, position(2) - yy, thisColor, 'LineWidth', 1.5);
+
+        % Draw a small open circle to mark the exact chosen point
+        plot(position(1), position(2), 'o', 'MarkerEdgeColor', thisColor, 'MarkerFaceColor', 'none', 'LineWidth', 1.5);
+
+        % Update the comment with this point's coordinates
+        comment = strcat(comment, sprintf("(%d,%d), ", position(1), position(2)));
+
+        figure(spec);
+        % Plot the spectrum at the given point, applying the vertical offset
+        plot(V_reduced, squeeze(didv(position(1), position(2), :)) + (k-1)*offset, thisColor, 'LineWidth', 1.5);
+    end
+end
+end


### PR DESCRIPTION
Slight modifications to block VS02A, as well as modifications to ginInputAll and replacing gridClickForSpectrum with a modified clickForSpectrum function. Altogether, this eliminates the errors thrown when a user exits the function early by hitting enter (e.g., selecting more clicks than you wanted).