### PR TITLE
modifications to VG01A (which visualizes a dI/dV stack as RGB images)

### DIFF
--- a/executable_script/mainTrunk.m
+++ b/executable_script/mainTrunk.m
@@ -1156,7 +1156,7 @@ clearvars dataset variableIn1 variableIn2 variableIn3 figName step_size numx num
 % - Select global or dynamic color range.
 % - Displays interactive stack with slice number and voltage.
 % - Adds button to capture displayed slice and voltage.
-% - Stores sliced_grid, sliceNumbers, voltages in data.grid
+% - Stores sliced_(dataset), sliceNumbers, voltages in data.(dataset)
 % - Passes LOGpath, LOGfile to gridSliceViewer for capture logging
 % Notes:
 % - No figure saving
@@ -1166,7 +1166,6 @@ dataset = 'grid';
 variableIn1 = 'dIdV';
 variableIn2 = 'V_reduced';
 variableIn3 = 'invgray';  % Colormap: 'invgray' (default), 'jet', 'hot', 'gray', 'parula', or any valid MATLAB colormap
-energyLayer = 255;
 variableOut1 = 'sliced_grid';
 variableOut2 = 'sliceNumbers';
 variableOut3 = 'voltages';
@@ -1191,16 +1190,16 @@ while true
 end
 
 % LOG data in/out
-LOGcomment = sprintf("dataset = %s; variableIn1 = %s; variableIn2 = %s; variableIn3 = %s; energyLayer = %d; rangeType = %s; variableOut1 = %s; variableOut2 = %s; variableOut3 = %s", ...
-    dataset, variableIn1, variableIn2, variableIn3, energyLayer, rangeType, variableOut1, variableOut2, variableOut3);
+LOGcomment = sprintf("dataset = %s; variableIn1 = %s; variableIn2 = %s; variableIn3 = %s; rangeType = %s; variableOut1 = %s; variableOut2 = %s; variableOut3 = %s", ...
+    dataset, variableIn1, variableIn2, variableIn3, rangeType, variableOut1, variableOut2, variableOut3);
 LOGcomment = logUsedBlocks(LOGpath, LOGfile, "VG01A", LOGcomment, 0);
 
 % Execute gridSliceViewer
 [data.(dataset).(variableOut1), data.(dataset).(variableOut2), data.(dataset).(variableOut3)] = ...
-    gridSliceViewer(data.(dataset).(variableIn1), data.(dataset).(variableIn2), energyLayer, rangeType, variableIn3, LOGpath, LOGfile);
+    gridSliceViewer(data.(dataset).(variableIn1), data.(dataset).(variableIn2), rangeType, variableIn3, LOGpath, LOGfile);
 LOGcomment = "Displayed interactive stack with slice number and voltage";
 LOGcomment = logUsedBlocks(LOGpath, LOGfile, "  ^  ", LOGcomment, 0);
 
 % Clear variables
-clearvars dataset variableIn1 variableIn2 variableIn3 energyLayer
+clearvars dataset variableIn1 variableIn2 variableIn3
 clearvars variableOut1 variableOut2 variableOut3 rangeChoice rangeType

--- a/executable_script/mainTrunk.m
+++ b/executable_script/mainTrunk.m
@@ -1172,9 +1172,6 @@ variableOut3 = 'voltages';
 
 %%%%%%%%%%%%%%%%%% DO NOT EDIT BELOW %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Close existing figures to prevent blank figure
-close all;
-
 % Prompt for range type
 while true
     rangeChoice = upper(input('Select color range type (G/g for Global, D/d for Dynamic): ', 's'));
@@ -1196,7 +1193,7 @@ LOGcomment = logUsedBlocks(LOGpath, LOGfile, "VG01A", LOGcomment, 0);
 
 % Execute gridSliceViewer
 [data.(dataset).(variableOut1), data.(dataset).(variableOut2), data.(dataset).(variableOut3)] = ...
-    gridSliceViewer(data.(dataset).(variableIn1), data.(dataset).(variableIn2), rangeType, variableIn3, LOGpath, LOGfile);
+    gridSliceViewer(data.(dataset).(variableIn1), data.(dataset).(variableIn2), rangeType, variableIn3, dataset, LOGpath, LOGfile);
 LOGcomment = "Displayed interactive stack with slice number and voltage";
 LOGcomment = logUsedBlocks(LOGpath, LOGfile, "  ^  ", LOGcomment, 0);
 

--- a/functions/3rdParty/imshow3D.m/imshow3D.m
+++ b/functions/3rdParty/imshow3D.m/imshow3D.m
@@ -1,138 +1,90 @@
-function  imshow3D( Img, disprange, initS )
+function imshow3D(Img, disprange, voltages, LOGpath, LOGfile)
 %IMSHOW3D displays 3D grayscale or RGB images in a slice by slice fashion
 %with mouse-based slice browsing and window and level adjustment control,
 %and auto slice browsing control.
 %
 % Usage:
-% imshow3D ( Image )
-% imshow3D ( Image , [] )
-% imshow3D ( Image , [LOW HIGH] )
-% imshow3D ( Image , [] , initsn )
-%   
+% imshow3D(Image)
+% imshow3D(Image, [LOW HIGH])
+% imshow3D(Image, [], voltages)
+% imshow3D(Image, [], voltages, LOGpath, LOGfile)
+%
 %    Image:      3D image MxNxKxC (K slices of MxN images) C is either 1
-%                (for grayscale images) or 3 (for RGB images)  
+%                (for grayscale images) or 3 (for RGB images)
 %    [LOW HIGH]: display range that controls the display intensity range of
 %                a grayscale image (default: the broadest available range)
-%    initsn:     The slice number to be displayed initially (default:
-%                mid-slice number) 
+%    voltages:   Voltage vector (column) for slice labels (default: 1:sno)
+%    LOGpath:    Path to log file (for capture logging)
+%    LOGfile:    Log file name (for capture logging)
 %
-% Use the scroll bar or mouse scroll wheel to switch between slices. To
-% adjust window and level values keep the mouse right button pressed, and
-% drag the mouse up and down (for level adjustment) or right and left (for
-% window adjustment). Window and level adjustment control works only for
-% grayscale images.
-% "Play" button displays all the slices as a sequence of frames. The time
-% interval value can also be adjusted (default time interval is 100 ms).
-% 
-% "Auto W/L" button adjust the window and level automatically for grayscale
-% images.
-%
-% While "Fine Tune" checkbox is checked the window/level adjustment gets 16
-% times less sensitive to mouse movement, to make it easier to control
-% display intensity rang.
-%
-% Note: The sensitivity of mouse-based window and level adjustment is set
-% based on the user-defined display intensity range; the wider the range,
-% the more sensitivity to mouse drag.
-% 
-% Note: IMSHOW3DFULL is a newer version of IMSHOW3D (also available on
-% MathWorks) that displays 3D grayscale or RGB images from three
-% perpendicular views (i.e., axial, sagittal, and coronal).
-% 
-%   Example
-%   --------
-%       % To display an image (MRI example)
-%       load mri 
-%       Image = squeeze(D); 
-%       figure, 
-%       imshow3D(Image) 
-%
-%       % To display the image, and adjust the display range
-%       figure,
-%       imshow3D(Image,[20 100]);
-%
-%       % To define the initial slice number
-%       figure,
-%       imshow3D(Image,[],5);
-%
-%   See also IMSHOW.
-
-%
-% - Maysam Shahedi (mshahedi@gmail.com)
-% - Released: 1.0.0   Date: 2013/04/15
-% - Revision: 1.1.0   Date: 2013/04/19
-% - Revision: 1.5.0   Date: 2016/09/22
-% - Revision: 1.6.0   Date: 2018/06/07
-% - Revision: 1.6.1   Date: 2018/10/29
-% 
+% Edited by James May 2025 to add capture button, set logging.
 
 sno = size(Img,3);  % number of slices
 S = round(sno/2);
-
-PlayFlag = false;   % Play flag, playing when it is 'True'
+PlayFlag = false;
 Tinterv = 100;
 
 global InitialCoord;
 
 MinV = 0;
 MaxV = max(Img(:));
-LevV = (double( MaxV) + double(MinV)) / 2;
+LevV = (double(MaxV) + double(MinV)) / 2;
 Win = double(MaxV) - double(MinV);
 WLAdjCoe = (Win + 1)/1024;
-FineTuneC = [1 1/16];    % Regular/Fine-tune mode coefficients
+FineTuneC = [1 1/16];
 
 if isa(Img,'uint8')
     MaxV = uint8(Inf);
     MinV = uint8(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'uint16')
     MaxV = uint16(Inf);
     MinV = uint16(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'uint32')
     MaxV = uint32(Inf);
     MinV = uint32(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'uint64')
     MaxV = uint64(Inf);
     MinV = uint64(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'int8')
     MaxV = int8(Inf);
     MinV = int8(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'int16')
     MaxV = int16(Inf);
     MinV = int16(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'int32')
     MaxV = int32(Inf);
     MinV = int32(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'int64')
     MaxV = int64(Inf);
     MinV = int64(-Inf);
-    LevV = (double( MaxV) + double(MinV)) / 2;
+    LevV = (double(MaxV) + double(MinV)) / 2;
     Win = double(MaxV) - double(MinV);
     WLAdjCoe = (Win + 1)/1024;
 elseif isa(Img,'logical')
     MaxV = 0;
     MinV = 1;
-    LevV =0.5;
+    LevV = 0.5;
     Win = 1;
     WLAdjCoe = 0.1;
 end    
@@ -143,22 +95,22 @@ LVFntSz = 9;
 WVFntSz = 9;
 BtnSz = 10;
 
-if (nargin < 3)
-    S = round(sno/2);
+% Handle voltages
+if nargin < 3 || isempty(voltages)
+    voltages = 1:sno;
 else
-    S = initS;
-    if S > sno
-        S = sno;
-        warning('Initial slice number out of range');
-    elseif S < 1
-        S = 1;
-        warning('Initial slice number out of range');
+    if length(voltages) ~= sno
+        error('Length of voltages (%d) must match number of slices (%d)', length(voltages), sno);
     end
 end
 
-if (nargin < 2)
-    [Rmin Rmax] = WL2R(Win, LevV);
-elseif numel(disprange) == 0
+% Handle LOGpath, LOGfile
+if nargin < 4
+    LOGpath = '';
+    LOGfile = '';
+end
+
+if nargin < 2 || isempty(disprange)
     [Rmin Rmax] = WL2R(Win, LevV);
 else
     LevV = (double(disprange(2)) + double(disprange(1))) / 2;
@@ -167,6 +119,7 @@ else
     [Rmin Rmax] = WL2R(Win, LevV);
 end
 
+% Use current figure
 clf
 axes('position',[0,0.2,1,0.8]), imshow(squeeze(Img(:,:,S,:)), [Rmin Rmax])
 
@@ -182,35 +135,41 @@ ChBx_Pos = [320 20 80 20];
 Play_Pos = [uint16(FigPos(3)-100)+40 45 30 20];
 Time_Pos = [uint16(FigPos(3)-100)+35 20 40 20];
 Ttxt_Pos = [uint16(FigPos(3)-100)-50 18 90 20];
+Capture_Pos = [uint16(FigPos(3)-200)+1 65 80 20]; % Next to Stxt_Pos
 
-% W/L Button styles:
+% W/L Button styles
 WL_BG = ones(Btn_Pos(4),Btn_Pos(3),3)*0.85;
-WL_BG(1,:,:) = 1; WL_BG(:,1,:) = 1; WL_BG(:,end-1,:) = 0.6; WL_BG(:,end,:) = 0.4; WL_BG(end,:,:) = 0.4;
+WL_BG(1,:,:) = 1; WL_BG(:,1,:) = 1; WL_BG(:,end-1,:) = 0.4; WL_BG(:,end,:) = 0.2; WL_BG(end,:,:) = 0.2;
 
-% Play Button styles:
+% Play Button styles
 Play_BG = ones(Play_Pos(4),Play_Pos(3),3)*0.85;
-Play_BG(1,:,:) = 1; Play_BG(:,1,:) = 1; Play_BG(:,end-1,:) = 0.6; Play_BG(:,end,:) = 0.4; Play_BG(end,:,:) = 0.4;
-Play_Symb = [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1; 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1; 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1;...
-             0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1; 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1; 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1;...
-             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0; 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1; 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1;...
-             0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1; 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1; 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1;...
-             0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+Play_BG(1,:,:) = 1; Play_BG(:,1,:) = 1; Play_BG(:,end-1,:) = 0.4; Play_BG(:,end,:) = 0.2; Play_BG(end,:,:) = 0.2;
+Play_Symb = [0,0,1,1,1,1,1,1,1,1,1,1,1,1; 0,0,0,0,1,1,1,1,1,1,1,1,1,1; 0,0,0,0,0,0,1,1,1,1,1,1,1,1;...
+             0,0,0,0,0,0,0,0,1,1,1,1,1,1; 0,0,0,0,0,0,0,0,0,0,1,1,1,1; 0,0,0,0,0,0,0,0,0,0,0,0,1,1;...
+             0,0,0,0,0,0,0,0,0,0,0,0,0,0; 0,0,0,0,0,0,0,0,0,0,0,0,1,1; 0,0,0,0,0,0,0,0,0,0,1,1,1,1;...
+             0,0,0,0,0,0,0,0,1,1,1,1,1,1; 0,0,0,0,0,0,1,1,1,1,1,1,1,1; 0,0,0,0,1,1,1,1,1,1,1,1,1,1;...
+             0,0,1,1,1,1,1,1,1,1,1,1,1,1];
 Play_BG(floor((Play_Pos(4)-13)/2)+1:floor((Play_Pos(4)-13)/2)+13,floor(Play_Pos(3)/2)-7:floor(Play_Pos(3)/2)+6,:) = ...
     repmat(Play_Symb,1,1,3) .* Play_BG(floor((Play_Pos(4)-13)/2)+1:floor((Play_Pos(4)-13)/2)+13,floor(Play_Pos(3)/2)-7:floor(Play_Pos(3)/2)+6,:);
 Pause_BG = ones(Play_Pos(4),Play_Pos(3),3)*0.85;
-Pause_BG(1,:,:) = 1; Pause_BG(:,1,:) = 1; Pause_BG(:,end-1,:) = 0.6; Pause_BG(:,end,:) = 0.4; Pause_BG(end,:,:) = 0.4;
-Pause_Symb = repmat([0, 0, 0, 1, 1, 1, 1, 0, 0, 0],13,1);
+Pause_BG(1,:,:) = 1; Pause_BG(:,1,:) = 1; Pause_BG(:,end-1,:) = 0.4; Pause_BG(:,end,:) = 0.2; Pause_BG(end,:,:) = 0.2;
+Pause_Symb = repmat([0,0,0,1,1,1,1,0,0,0],13,1);
 Pause_BG(floor((Play_Pos(4)-13)/2)+1:floor((Play_Pos(4)-13)/2)+13,floor(Play_Pos(3)/2)-5:floor(Play_Pos(3)/2)+4,:) = ...
     repmat(Pause_Symb,1,1,3) .* Pause_BG(floor((Play_Pos(4)-13)/2)+1:floor((Play_Pos(4)-13)/2)+13,floor(Play_Pos(3)/2)-5:floor(Play_Pos(3)/2)+4,:);
 
+% Capture Button styles
+Capture_BG = ones(Capture_Pos(4),Capture_Pos(3),3)*0.6; % Light blue base
+Capture_BG(:,:,1) = 0.6; Capture_BG(:,:,2) = 0.8; Capture_BG(:,:,3) = 1;
+Capture_BG(1,:,:) = 1; Capture_BG(:,1,:) = 1; Capture_BG(:,end-1,:) = 0.4; Capture_BG(:,end,:) = 0.2; Capture_BG(end,:,:) = 0.2;
 
 if sno > 1
     shand = uicontrol('Style', 'slider','Min',1,'Max',sno,'Value',S,'SliderStep',[1/(sno-1) 10/(sno-1)],'Position', S_Pos,'Callback', {@SliceSlider, Img});
-    stxthand = uicontrol('Style', 'text','Position', Stxt_Pos,'String',sprintf('Slice# %d / %d',S, sno), 'FontSize', SFntSz);
-    playhand = uicontrol('Style', 'pushbutton','Position', Play_Pos, 'Callback' , @Play);
+    stxthand = uicontrol('Style', 'text','Position', Stxt_Pos,'String',sprintf('Slice# %d (V = %.4f) / %d',S, voltages(S), sno), 'FontSize', SFntSz);
+    playhand = uicontrol('Style', 'pushbutton','Position', Play_Pos, 'Callback', @Play);
     set(playhand, 'cdata', Play_BG)
     ttxthand = uicontrol('Style', 'text','Position', Ttxt_Pos,'String','Interval (ms): ',  'FontSize', txtFntSz);
     timehand = uicontrol('Style', 'edit','Position', Time_Pos,'String',sprintf('%d',Tinterv), 'BackgroundColor', [1 1 1], 'FontSize', LVFntSz,'Callback', @TimeChanged);
+    capturehand = uicontrol('Style', 'pushbutton','Position', Capture_Pos,'String','Capture', 'FontSize', BtnSz, 'FontWeight', 'bold', 'CData', Capture_BG, 'Callback', @CaptureSlice);
 else
     stxthand = uicontrol('Style', 'text','Position', Stxt_Pos,'String','2D image', 'FontSize', SFntSz);
 end    
@@ -218,16 +177,15 @@ ltxthand = uicontrol('Style', 'text','Position', Ltxt_Pos,'String','Level: ',  '
 wtxthand = uicontrol('Style', 'text','Position', Wtxt_Pos,'String','Window: ',  'FontSize', txtFntSz);
 lvalhand = uicontrol('Style', 'edit','Position', Lval_Pos,'String',sprintf('%6.0f',LevV), 'BackgroundColor', [1 1 1], 'FontSize', LVFntSz,'Callback', @WinLevChanged);
 wvalhand = uicontrol('Style', 'edit','Position', Wval_Pos,'String',sprintf('%6.0f',Win), 'BackgroundColor', [1 1 1], 'FontSize', WVFntSz,'Callback', @WinLevChanged);
-Btnhand = uicontrol('Style', 'pushbutton','Position', Btn_Pos,'String','Auto W/L', 'FontSize', BtnSz, 'Callback' , @AutoAdjust);
+Btnhand = uicontrol('Style', 'pushbutton','Position', Btn_Pos,'String','Auto W/L', 'FontSize', BtnSz, 'Callback', @AutoAdjust);
 set(Btnhand, 'cdata', WL_BG)
 ChBxhand = uicontrol('Style', 'checkbox','Position', ChBx_Pos,'String','Fine-tune', 'FontSize', txtFntSz);
 
-set (gcf, 'WindowScrollWheelFcn', @mouseScroll);
-set (gcf, 'ButtonDownFcn', @mouseClick);
+set(gcf, 'WindowScrollWheelFcn', @mouseScroll);
+set(gcf, 'ButtonDownFcn', @mouseClick);
 set(get(gca,'Children'),'ButtonDownFcn', @mouseClick);
 set(gcf,'WindowButtonUpFcn', @mouseRelease)
 set(gcf,'ResizeFcn', @figureResized)
-
 
 % -=< Figure resize callback function >=-
     function figureResized(object, eventdata)
@@ -237,11 +195,13 @@ set(gcf,'ResizeFcn', @figureResized)
         Play_Pos = [uint16(FigPos(3)-100)+40 45 30 20];
         Time_Pos = [uint16(FigPos(3)-100)+35 20 40 20];
         Ttxt_Pos = [uint16(FigPos(3)-100)-50 18 90 20];
+        Capture_Pos = [uint16(FigPos(3)-200)+1 65 80 20];
         if sno > 1
             set(shand,'Position', S_Pos);
             set(playhand, 'Position', Play_Pos)
             set(ttxthand, 'Position', Ttxt_Pos)
             set(timehand, 'Position', Time_Pos)
+            set(capturehand, 'Position', Capture_Pos)
         end
         set(stxthand,'Position', Stxt_Pos);
         set(ltxthand,'Position', Ltxt_Pos);
@@ -253,19 +213,19 @@ set(gcf,'ResizeFcn', @figureResized)
     end
 
 % -=< Slice slider callback function >=-
-    function SliceSlider (hObj,event, Img)
+    function SliceSlider(hObj, event, Img)
         S = round(get(hObj,'Value'));
         set(get(gca,'children'),'cdata',squeeze(Img(:,:,S,:)))
         caxis([Rmin Rmax])
         if sno > 1
-            set(stxthand, 'String', sprintf('Slice# %d / %d',S, sno));
+            set(stxthand, 'String', sprintf('Slice# %d (V = %.4f) / %d', S, voltages(S), sno));
         else
             set(stxthand, 'String', '2D image');
         end
     end
 
 % -=< Mouse scroll wheel callback function >=-
-    function mouseScroll (object, eventdata)
+    function mouseScroll(object, eventdata)
         UPDN = eventdata.VerticalScrollCount;
         S = S - UPDN;
         if (S < 1)
@@ -275,7 +235,7 @@ set(gcf,'ResizeFcn', @figureResized)
         end
         if sno > 1
             set(shand,'Value',S);
-            set(stxthand, 'String', sprintf('Slice# %d / %d',S, sno));
+            set(stxthand, 'String', sprintf('Slice# %d (V = %.4f) / %d', S, voltages(S), sno));
         else
             set(stxthand, 'String', '2D image');
         end
@@ -283,14 +243,14 @@ set(gcf,'ResizeFcn', @figureResized)
     end
 
 % -=< Mouse button released callback function >=-
-    function mouseRelease (object,eventdata)
+    function mouseRelease(object, eventdata)
         set(gcf, 'WindowButtonMotionFcn', '')
     end
 
 % -=< Mouse click callback function >=-
-    function mouseClick (object, eventdata)
+    function mouseClick(object, eventdata)
         MouseStat = get(gcbf, 'SelectionType');
-        if (MouseStat(1) == 'a')        %   RIGHT CLICK
+        if (MouseStat(1) == 'a')  % RIGHT CLICK
             InitialCoord = get(0,'PointerLocation');
             set(gcf, 'WindowButtonMotionFcn', @WinLevAdj);
         end
@@ -299,15 +259,13 @@ set(gcf,'ResizeFcn', @figureResized)
 % -=< Window and level mouse adjustment >=-
     function WinLevAdj(varargin)
         PosDiff = get(0,'PointerLocation') - InitialCoord;
-
         Win = Win + PosDiff(1) * WLAdjCoe * FineTuneC(get(ChBxhand,'Value')+1);
         LevV = LevV - PosDiff(2) * WLAdjCoe * FineTuneC(get(ChBxhand,'Value')+1);
         if (Win < 1)
             Win = 1;
         end
-
-        [Rmin, Rmax] = WL2R(Win,LevV);
-        caxis([Rmin, Rmax])
+        [Rmin, Rmax] = WL2R(Win, LevV);
+        caxis([Rmin Rmax])
         set(lvalhand, 'String', sprintf('%6.0f',LevV));
         set(wvalhand, 'String', sprintf('%6.0f',Win));
         InitialCoord = get(0,'PointerLocation');
@@ -315,19 +273,17 @@ set(gcf,'ResizeFcn', @figureResized)
 
 % -=< Window and level text adjustment >=-
     function WinLevChanged(varargin)
-
         LevV = str2double(get(lvalhand, 'string'));
         Win = str2double(get(wvalhand, 'string'));
         if (Win < 1)
             Win = 1;
         end
-
-        [Rmin, Rmax] = WL2R(Win,LevV);
-        caxis([Rmin, Rmax])
+        [Rmin, Rmax] = WL2R(Win, LevV);
+        caxis([Rmin Rmax])
     end
 
 % -=< Window and level to range conversion >=-
-    function [Rmn Rmx] = WL2R(W,L)
+    function [Rmn Rmx] = WL2R(W, L)
         Rmn = L - (W/2);
         Rmx = L + (W/2);
         if (Rmn >= Rmx)
@@ -336,18 +292,18 @@ set(gcf,'ResizeFcn', @figureResized)
     end
 
 % -=< Window and level auto adjustment callback function >=-
-    function AutoAdjust(object,eventdata)
+    function AutoAdjust(object, eventdata)
         Win = double(max(Img(:))-min(Img(:)));
-        Win (Win < 1) = 1;
+        Win(Win < 1) = 1;
         LevV = double(min(Img(:)) + (Win/2));
-        [Rmin, Rmax] = WL2R(Win,LevV);
-        caxis([Rmin, Rmax])
+        [Rmin, Rmax] = WL2R(Win, LevV);
+        caxis([Rmin Rmax])
         set(lvalhand, 'String', sprintf('%6.0f',LevV));
         set(wvalhand, 'String', sprintf('%6.0f',Win));
     end
 
 % -=< Play button callback function >=-
-    function Play (hObj,event)
+    function Play(hObj, event)
         PlayFlag = ~PlayFlag;
         if PlayFlag
             set(playhand, 'cdata', Pause_BG)
@@ -360,16 +316,50 @@ set(gcf,'ResizeFcn', @figureResized)
                 S = 1;
             end
             set(shand,'Value',S);
-            set(stxthand, 'String', sprintf('Slice# %d / %d',S, sno));
+            set(stxthand, 'String', sprintf('Slice# %d (V = %.4f) / %d', S, voltages(S), sno));
             set(get(gca,'children'),'cdata',squeeze(Img(:,:,S,:)))
             pause(Tinterv/1000)
         end
     end
 
-% -=< Time interval adjustment callback function>=-
+% -=< Time interval adjustment callback function >=-
     function TimeChanged(varargin)
         Tinterv = str2double(get(timehand, 'string'));
     end
-    
+
+% -=< Capture slice callback function >=-
+    function CaptureSlice(~, ~)
+        % Load or initialize data.grid
+        if evalin('base', 'exist(''data'', ''var'')')
+            data = evalin('base', 'data');
+        else
+            data.grid = struct();
+        end
+        
+        % Initialize or append to arrays
+        if ~isfield(data.grid, 'selectedSlice')
+            data.grid.selectedSlice = [];
+            data.grid.selectedVoltage = [];
+            data.grid.selectedSliceData = [];
+        end
+        
+        % Append current slice
+        data.grid.selectedSlice = [data.grid.selectedSlice; S];
+        data.grid.selectedVoltage = [data.grid.selectedVoltage; voltages(S)];
+        data.grid.selectedSliceData = cat(3, data.grid.selectedSliceData, squeeze(Img(:,:,S,:)));
+        
+        % Save to base workspace
+        assignin('base', 'data', data);
+        
+        % Confirmation message
+        fprintf('Captured Slice# %d (V = %.4f)\n', S, voltages(S));
+        
+        % Log capture
+        if ~isempty(LOGpath) && ~isempty(LOGfile) && ischar(LOGpath) && ischar(LOGfile)
+            LOGcomment = sprintf('Captured Slice# %d (V = %.4f)', S, voltages(S));
+            logUsedBlocks(LOGpath, LOGfile, '  ^  ', LOGcomment, 0);
+        else
+            warning('Logging skipped: LOGpath or LOGfile invalid or undefined.');
+        end
+    end
 end
-% -=< Maysam Shahedi (mshahedi@gmail.com), October 29, 2018>=-

--- a/functions/3rdParty/imshow3D.m/imshow3D_LAIR.m
+++ b/functions/3rdParty/imshow3D.m/imshow3D_LAIR.m
@@ -329,24 +329,23 @@ set(gcf,'ResizeFcn', @figureResized)
 
 % -=< Capture slice callback function >=-
     function CaptureSlice(~, ~)
-        % Load or initialize data.grid
+        % Load or initialize data.(dataset)
         if evalin('base', 'exist(''data'', ''var'')')
             data = evalin('base', 'data');
         else
-            data.grid = struct();
+            data.(dataset) = struct();
         end
         
         % Initialize or append to arrays
-        if ~isfield(data.grid, 'selectedSlice')
-            data.grid.selectedSlice = [];
-            data.grid.selectedVoltage = [];
-            data.grid.selectedSliceData = [];
+        if ~isfield(data.(dataset), 'selectedSlice')
+            data.(dataset).selectedSlice = [];
+            data.(dataset).selectedVoltage = [];
+
         end
         
         % Append current slice
-        data.grid.selectedSlice = [data.grid.selectedSlice; S];
-        data.grid.selectedVoltage = [data.grid.selectedVoltage; voltages(S)];
-        data.grid.selectedSliceData = cat(3, data.grid.selectedSliceData, squeeze(Img(:,:,S,:)));
+        data.(dataset).selectedSlice = [data.(dataset).selectedSlice; S];
+        data.(dataset).selectedVoltage = [data.(dataset).selectedVoltage; voltages(S)];
         
         % Save to base workspace
         assignin('base', 'data', data);

--- a/functions/visualization/gridSliceViewer.m
+++ b/functions/visualization/gridSliceViewer.m
@@ -1,178 +1,110 @@
-function sliced_grid = gridSliceViewer(data, EnergyLayer, rangeType, colormapName)
-% SLICEVIEWERDEC2 Processes and displays 3D dIdV data with selectable range type, colormap, and coordinate mapping
-% Merged version of sliceViewer2 and d3gridDisplay by Jiabin Nov 2024
+function [sliced_grid, sliceNumbers, voltages] = gridSliceViewer(data, V, EnergyLayer, rangeType, colormapName, LOGpath, LOGfile)
+% GRIDSLICEVIEWER Processes 3D dIdV data into an RGB image stack for visualization.
+%   Edited by Jiabin Nov 2024, James May 2025
 %
 % Inputs:
-%   data: Raw dIdV data - 3D matrix of scanning tunneling spectroscopy data
-%   EnergyLayer: Number of layers - Integer specifying total layers
-%   rangeType: Type of range for visualization ('global' or 'dynamic')
-%   colormapName: Name of the colormap to use (default is 'invgray')
+%   data: 3D matrix (x, y, V) of dIdV data.
+%   V: Voltage vector (column) matching data's third dimension.
+%   EnergyLayer: Number of layers to process (max = size(data, 3)).
+%   rangeType: 'global' or 'dynamic'.
+%   colormapName: Colormap name (default 'invgray').
+%   LOGpath: Path to log file (for capture logging).
+%   LOGfile: Log file name (for capture logging).
 %
-% Output:
-%   sliced_grid: 4D matrix containing processed image slices
+% Outputs:
+%   sliced_grid: 4D RGB stack (x, y, EnergyLayer, 3).
+%   sliceNumbers: Indices (1:EnergyLayer) as column.
+%   voltages: Corresponding voltages from V as column.
 
 arguments
-    data                (:,:,:) {mustBeNumeric}
-    EnergyLayer         (1,1) {mustBeInteger, mustBePositive}
-    rangeType           (1,:) char {mustBeMember(rangeType, {'global', 'dynamic'})}
-    colormapName        (1,:) char = 'invgray'
+    data (:,:,:) {mustBeNumeric}
+    V (:,1) {mustBeNumeric}
+    EnergyLayer (1,1) {mustBeInteger, mustBePositive}
+    rangeType (1,:) char {mustBeMember(rangeType, {'global', 'dynamic'})}
+    colormapName (1,:) char = 'invgray'
+    LOGpath (1,:) char = ''
+    LOGfile (1,:) char = ''
 end
 
-% Default parameters
-if isempty(colormapName)
-    colormapName = 'invgray';
+% Validate inputs
+if size(data, 3) ~= length(V)
+    error('Length of V (%d) must match third dimension of data (%d)', length(V), size(data, 3));
+end
+if EnergyLayer > size(data, 3)
+    EnergyLayer = size(data, 3);
+    warning('EnergyLayer adjusted to match data: %d', EnergyLayer);
 end
 
-% Load specified colormap
-try
-    if strcmp(colormapName, 'invgray')
-        load('InverseGray', 'invgray');
-        map = invgray;
-    else
-        % Use MATLAB's built-in colormap
-        map = colormap(colormapName);
-    end
-catch
-    % Fallback to default inverse gray if colormap loading fails
-    warning('Could not load specified colormap. Falling back to invgray.');
+% Load colormap
+if strcmp(colormapName, 'invgray')
     load('InverseGray', 'invgray');
     map = invgray;
+else
+    try
+        map = colormap(colormapName);
+    catch
+        warning('Invalid colormap "%s". Using invgray.', colormapName);
+        load('InverseGray', 'invgray');
+        map = invgray;
+    end
 end
 
-% Validate EnergyLayer against data size
-if EnergyLayer > size(data, 3) + 1
-    error('EnergyLayer cannot be larger than the number of layers in the input data plus one');
-end
+% Prepare data
+Grid = permute(data, [2 1 3]);
+Grid = flip(Grid, 1);
 
-% Grid: output variable to be dispalyed by imshow3D
-% Transpose and flip to match Cartesian coordinates
-Grid = permute(data, [2 1 3]);  % Swap x and y dimensions
-Grid = flip(Grid, 1);  % Flip vertically to match Cartesian orientation
-
-% Initialize visualization
-figure('Name', sprintf('3D Grid View - %s Range, %s Colormap', rangeType, colormapName));
-
-% Determine global min and max values if global range is selected
+% Set range
 if strcmp(rangeType, 'global')
     globalMin = min(Grid(:));
     globalMax = max(Grid(:));
 end
 
-% Pre-allocate the sliced grid array
-sliced_grid = zeros(size(Grid,1), size(Grid,2), size(Grid,3), 3);
+% Pre-allocate output
+sliced_grid = zeros(size(Grid, 1), size(Grid, 2), EnergyLayer, 3);
+sliceNumbers = (1:EnergyLayer)';
+voltages = V(1:EnergyLayer);
 
-% Parameter for dynamic range contrast
-nos = 8;
-
-% Convert Grid to image format using the colormap
-for k = 1:size(Grid, 3)
+% Process slices
+for k = 1:EnergyLayer
+    sliceData = Grid(:,:,k);
     if strcmp(rangeType, 'dynamic')
-        MeddIdV = median(median(Grid(:,:,k)));
-        Stdv = std(std(Grid(:,:,k)));
-        range = [MeddIdV-nos*Stdv MeddIdV+nos*Stdv];
+        med = median(sliceData(:));
+        stdv = std(sliceData(:));
+        range = [med - 8*stdv, med + 8*stdv];
     else
-        range = [globalMin globalMax];
+        range = [globalMin, globalMax];
     end
-    sliced_grid(:,:,k,:) = mat2im(Grid(:,:,k), map, range);
+    sliced_grid(:,:,k,:) = mat2im(sliceData, map, range);
 end
 
-% Display the 3D image stack
-imshow3D(sliced_grid);
-end
+% Display
+figure('Name', sprintf('3D Grid View - %s Range, %s Colormap', rangeType, colormapName));
+imshow3D(sliced_grid, [], voltages, LOGpath, LOGfile);
 
-
-function im=mat2im(mat,cmap,limits)
-    % mat2im - convert to rgb image
-    %
-    % function im=mat2im(mat,cmap,maxVal)
-    %
-    % Description: 
-    % Uses vectorized code to convert matrix "mat" to an m-by-n-by-3
-    % image matrix which can be handled by the Mathworks image-processing
-    % functions. The the image is created using a specified color-map
-    % and, optionally, a specified maximum value. Note that it discards
-    % negative values!
-    %
-    % INPUTS
-    % mat     - an m-by-n matrix  
-    % cmap    - an m-by-3 color-map matrix. e.g. hot(100). If the colormap has 
-    %           few rows (e.g. less than 20 or so) then the image will appear 
-    %           contour-like.
-    % limits  - by default the image is normalised to it's max and min values
-    %           so as to use the full dynamic range of the
-    %           colormap. Alternatively, it may be normalised to between
-    %           limits(1) and limits(2). Nan values in limits are ignored. So
-    %           to clip the max alone you would do, for example, [nan, 2]
-    %          
-    %
-    % OUTPUTS
-    % im - an m-by-n-by-3 image matrix  
-    %
-    %
-    % Example 1 - combine multiple color maps on one figure 
-    % clf, colormap jet, r=rand(40);
-    % subplot(1,3,1),imagesc(r), axis equal off , title('jet')
-    % subplot(1,3,2),imshow(mat2im(r,hot(100))) , title('hot')
-    % subplot(1,3,3),imshow(mat2im(r,summer(100))), title('summer')
-    % colormap winter %changes colormap in only the first panel
-    %
-    % Example 2 - clipping
-    % p=peaks(128); J=jet(100);
-    % subplot(2,2,1), imshow(mat2im(p,J)); title('Unclipped')
-    % subplot(2,2,2), imshow(mat2im(p,J,[0,nan])); title('Remove pixels <0')
-    % subplot(2,2,3), imshow(mat2im(p,J,[nan,0])); title('Remove pixels >0')
-    % subplot(2,2,4), imshow(mat2im(p,J,[-1,3])); title('Plot narrow pixel range')
-    %
-    % Rob Campbell - April 2009
-    %
-    % See Also: ind2rgb, imadjust
-    
-    
-    %Check input arguments
-    error(nargchk(2,3,nargin));
-    
-    if ~isa(mat, 'double')
-        mat = double(mat)+1;    % Switch to one based indexing
+    % Nested mat2im
+    function im = mat2im(mat, cmap, limits)
+        if ~isa(mat, 'double')
+            mat = double(mat) + 1;
+        end
+        if ~isnumeric(cmap)
+            error('cmap must be a numeric colormap');
+        end
+        if nargin < 3
+            minVal = min(mat(:));
+            maxVal = max(mat(:));
+        else
+            minVal = limits(1);
+            if isnan(minVal), minVal = min(mat(:)); end
+            mat(mat < minVal) = minVal;
+            maxVal = limits(2);
+            if isnan(maxVal), maxVal = max(mat(:)); end
+            mat(mat > maxVal) = maxVal;
+        end
+        L = size(cmap, 1);
+        mat = mat - minVal;
+        mat = (mat / (maxVal - minVal)) * (L - 1);
+        mat = mat + 1;
+        mat = round(mat);
+        im = reshape(cmap(mat(:), :), [size(mat), 3]);
     end
-    
-    if ~isnumeric(cmap)
-        error('cmap must be a colormap, such as jet(100)')
-    end
-    
-    
-    %Clip if desired
-    L=length(cmap);
-    if nargin==3 && length(limits)==1
-        warning('limits should be vector of length of 2. Assuming a max value was specified.')
-        limits=[nan,limits];
-    end
-    
-    
-    if nargin==3
-        minVal=limits(1);
-        if isnan(minVal), minVal=min(mat(:)); end    
-        mat(mat<minVal)=minVal;
-        
-        maxVal=limits(2);
-        if isnan(maxVal), maxVal=max(mat(:)); end
-        mat(mat>maxVal)=maxVal;        
-    else
-    minVal=min(mat(:));
-    maxVal=max(mat(:));
-    end
-    
-    
-    %Normalise 
-    mat=mat-minVal;
-    mat=(mat/(maxVal-minVal))*(L-1);
-    mat=mat+1;
-    
-    
-    %convert to indecies 
-    mat=round(mat); 
-    
-    
-    %Vectorised way of making the image matrix 
-    im=reshape(cmap(mat(:),:),[size(mat),3]);
-    
 end

--- a/functions/visualization/gridSliceViewer.m
+++ b/functions/visualization/gridSliceViewer.m
@@ -1,25 +1,22 @@
-function [sliced_grid, sliceNumbers, voltages] = gridSliceViewer(data, V, EnergyLayer, rangeType, colormapName, LOGpath, LOGfile)
+function [sliced_grid, sliceNumbers, voltages] = gridSliceViewer(data, V, rangeType, colormapName, LOGpath, LOGfile)
 % GRIDSLICEVIEWER Processes 3D dIdV data into an RGB image stack for visualization.
 %   Edited by Jiabin Nov 2024, James May 2025
 %
 % Inputs:
 %   data: 3D matrix (x, y, V) of dIdV data.
 %   V: Voltage vector (column) matching data's third dimension.
-%   EnergyLayer: Number of layers to process (max = size(data, 3)).
 %   rangeType: 'global' or 'dynamic'.
 %   colormapName: Colormap name (default 'invgray').
 %   LOGpath: Path to log file (for capture logging).
 %   LOGfile: Log file name (for capture logging).
 %
 % Outputs:
-%   sliced_grid: 4D RGB stack (x, y, EnergyLayer, 3).
-%   sliceNumbers: Indices (1:EnergyLayer) as column.
+%   sliced_grid: 4D RGB stack (x, y, slices, 3).
 %   voltages: Corresponding voltages from V as column.
 
 arguments
     data (:,:,:) {mustBeNumeric}
     V (:,1) {mustBeNumeric}
-    EnergyLayer (1,1) {mustBeInteger, mustBePositive}
     rangeType (1,:) char {mustBeMember(rangeType, {'global', 'dynamic'})}
     colormapName (1,:) char = 'invgray'
     LOGpath (1,:) char = ''
@@ -29,10 +26,6 @@ end
 % Validate inputs
 if size(data, 3) ~= length(V)
     error('Length of V (%d) must match third dimension of data (%d)', length(V), size(data, 3));
-end
-if EnergyLayer > size(data, 3)
-    EnergyLayer = size(data, 3);
-    warning('EnergyLayer adjusted to match data: %d', EnergyLayer);
 end
 
 % Load colormap
@@ -60,12 +53,12 @@ if strcmp(rangeType, 'global')
 end
 
 % Pre-allocate output
-sliced_grid = zeros(size(Grid, 1), size(Grid, 2), EnergyLayer, 3);
-sliceNumbers = (1:EnergyLayer)';
-voltages = V(1:EnergyLayer);
+sliced_grid = zeros(size(Grid, 1), size(Grid, 2), size(data, 3), 3);
+sliceNumbers = (1:size(data, 3))';
+voltages = V(1:size(data, 3));
 
 % Process slices
-for k = 1:EnergyLayer
+for k = 1:size(data, 3)
     sliceData = Grid(:,:,k);
     if strcmp(rangeType, 'dynamic')
         med = median(sliceData(:));
@@ -79,7 +72,7 @@ end
 
 % Display
 figure('Name', sprintf('3D Grid View - %s Range, %s Colormap', rangeType, colormapName));
-imshow3D(sliced_grid, [], voltages, LOGpath, LOGfile);
+imshow3D_LAIR(sliced_grid, [], voltages, LOGpath, LOGfile);
 
     % Nested mat2im
     function im = mat2im(mat, cmap, limits)

--- a/functions/visualization/gridSliceViewer.m
+++ b/functions/visualization/gridSliceViewer.m
@@ -1,4 +1,4 @@
-function [sliced_grid, sliceNumbers, voltages] = gridSliceViewer(data, V, rangeType, colormapName, LOGpath, LOGfile)
+function [sliced_grid, sliceNumbers, voltages] = gridSliceViewer(data, V, rangeType, colormapName, dataset, LOGpath, LOGfile)
 % GRIDSLICEVIEWER Processes 3D dIdV data into an RGB image stack for visualization.
 %   Edited by Jiabin Nov 2024, James May 2025
 %
@@ -19,6 +19,7 @@ arguments
     V (:,1) {mustBeNumeric}
     rangeType (1,:) char {mustBeMember(rangeType, {'global', 'dynamic'})}
     colormapName (1,:) char = 'invgray'
+    dataset (1,:) char = 'grid'
     LOGpath (1,:) char = ''
     LOGfile (1,:) char = ''
 end
@@ -72,7 +73,7 @@ end
 
 % Display
 figure('Name', sprintf('3D Grid View - %s Range, %s Colormap', rangeType, colormapName));
-imshow3D_LAIR(sliced_grid, [], voltages, LOGpath, LOGfile);
+imshow3D_LAIR(sliced_grid, [], voltages, dataset, LOGpath, LOGfile);
 
     % Nested mat2im
     function im = mat2im(mat, cmap, limits)

--- a/functions/visualization/imshow3D_LAIR.m
+++ b/functions/visualization/imshow3D_LAIR.m
@@ -1,4 +1,4 @@
-function imshow3D_LAIR(Img, disprange, voltages, LOGpath, LOGfile)
+function imshow3D_LAIR(Img, disprange, voltages, dataset, LOGpath, LOGfile)
 %IMSHOW3D displays 3D grayscale or RGB images in a slice by slice fashion
 %with mouse-based slice browsing and window and level adjustment control,
 %and auto slice browsing control.
@@ -14,6 +14,7 @@ function imshow3D_LAIR(Img, disprange, voltages, LOGpath, LOGfile)
 %    [LOW HIGH]: display range that controls the display intensity range of
 %                a grayscale image (default: the broadest available range)
 %    voltages:   Voltage vector (column) for slice labels (default: 1:sno)
+%    dataset:    Name of the dataset field in data structure (e.g., 'grid')
 %    LOGpath:    Path to log file (for capture logging)
 %    LOGfile:    Log file name (for capture logging)
 %
@@ -104,8 +105,12 @@ else
     end
 end
 
-% Handle LOGpath, LOGfile
-if nargin < 4
+% Handle dataset, LOGpath, LOGfile
+if nargin < 5
+    dataset = 'grid'; % Default if not provided
+    LOGpath = '';
+    LOGfile = '';
+elseif nargin < 6
     LOGpath = '';
     LOGfile = '';
 end


### PR DESCRIPTION
**For VG01A:**

- modified call to gridSliceViewer to pass LOGpath and LOGfile as additional arguments, to enable capture logging in imshow3D
- updated documentation to note the new logging functionality for slice captures

**for gridSliceViewer:**

- added LOGpath and LOGfile as optional input arguments, with default values of empty strings ('')
- passed LOGpath and LOGfile to imshow3D in the display call, to support logging of captured slices
- updated documentation to reflect the new input arguments for logging

**For imshow3D:**

- added LOGpath and LOGfile as input arguments, with default values of empty strings ('') to receive logging parameters from gridSliceViewer
- added a “Capture” button to store the current slice, its voltage, and RGB data in data.grid (fields: selectedSlice, selectedVoltage, selectedSliceData) in the workspace
- added logging for slice captures in CaptureSlice callback, using logUsedBlocks, with comment format Captured Slice# %d (V = %.4f
- included validation in CaptureSlice to check ~isempty(LOGpath) && ~isempty(LOGfile) && ischar(LOGpath) && ischar(LOGfile) before logging, with a warning if logging is skipped
- updated documentation for new arguments and capture functionality