### PR TITLE
Freely select and rename channels when loading Nanonis data

### DIFF
--- a/functions/loading/load_grid_Nanonis.m
+++ b/functions/loading/load_grid_Nanonis.m
@@ -1,5 +1,6 @@
 function grid = load_grid_Nanonis(folder,gridFileName)
 %Wrapper function for loading grids from Nanonis
+%   V.K. - 2024, J.T. - 2026
 %   Uses the Nanonis-made load3ds.m function, processes the data into a structure 
 % Input: 
 %   folder: string of folder containing data
@@ -51,108 +52,73 @@ bias_end = par{1,1}(2);
 number_bias_points = header.points;
 grid.V = transpose(linspace(bias_start,bias_end,number_bias_points));
 
-%Get the channels from the data: 
-I_all = zeros(number_x_points, number_y_points, number_bias_points);
-lock_in_all = zeros(number_x_points, number_y_points, number_bias_points);
-I_backward_all = zeros(number_x_points, number_y_points, number_bias_points);
-z_all = zeros(number_x_points, number_y_points, number_bias_points);
-z_backward_all = zeros(number_x_points, number_y_points, number_bias_points);
-other_channel_all = zeros(number_x_points, number_y_points, number_bias_points);
+% Create array of default selected channels
+number_channels = size(data{1,1},2);
+defaultChannelSelection(number_channels) = struct('channelName', [], 'fieldName', [], 'selected', []);
 
-for x = 1:number_x_points
-    for y = 1:number_y_points
-        for channel = 1:size(data{x,y},2)
-            if header.channels{channel} == "Current (A)"
-                I_all(x,y,:) = data{x,y}(:,channel); %Note: I_all is the forward scan by default
-            elseif header.channels{channel} == "LI D1 X 1 omega (A)"
-                lock_in_all(x,y,:) = data{x,y}(:,channel);
-            elseif header.channels{channel} == "Current [bwd] (A)"
-                I_backward_all(x,y,:) = data{x,y}(:,channel);
-            elseif header.channels{channel} == "Z (m)"
-                z_all(x,y,:) = data{x,y}(:,channel);
-            elseif header.channels{channel} == "Z [bwd] (m)"
-                z_backward_all(x,y,:) = data{x,y}(:,channel);
-            else
-                other_channel_all(x,y,:) = data{x,y}(:,channel);
-            end
-        end
+for channel = 1:number_channels
+    switch header.channels{channel}
+        case "Z (m)"
+            fieldName = "z";
+            selected = true;
+        case "Z [bwd] (m)"
+            fieldName = "z_backward";
+            selected = true;
+        case "Current (A)"
+            fieldName = "I";
+            selected = true;
+        case "Current [bwd] (A)"
+            fieldName = "I_backward";
+            selected = true;
+        case "LI D1 X 1 omega (A)"
+            fieldName = "lock_in";
+            selected = true;
+        otherwise
+            fieldName = "";
+            selected = false;
     end
+
+    defaultChannelSelection(channel).channelName = header.channels{channel};
+    defaultChannelSelection(channel).fieldName = fieldName;
+    defaultChannelSelection(channel).selected = selected;
 end
 
-%The energy dimension of z is reductive, removing it:
-z_all = z_all(:,:,1);
-z_backward_all = z_backward_all(:,:,1);
-
+% Prompt user to select channels to load
+channelSelection = selectChannels(defaultChannelSelection);
 
 % This section is to determine if we have a partial image and remove 0 values if so. 
 % Note this wasn't necessary for x or V since they're always full
-[x_coordinates,y_coordinates] = find(all(I_all,3)); %pixels where there are spectra
+[~,y_coordinates] = find(all(data{1, 1}(3, 1))); %pixels where there are spectra
 
-%Check if the grid is finished, assign variables accordingly
-if all(I_all,'all') %grid is finished
-    grid.I = I_all;
-    if any(lock_in_all,'all')
-        grid.lock_in = lock_in_all;
-    end
-    if any(I_backward_all,'all')
-        grid.I_backward = I_backward_all;
-    end
-    if any(z_all,'all')
-        grid.z = z_all;
-        %Convert from m to nm
-        grid.z = grid.z .* 1e9;
-    end
-    if any(z_backward_all,'all')
-        grid.z_backward = z_backward_all;
-        %Convert from m to nm
-        grid.z_backward = grid.z_backward .* 1e9;
-    end
-    if any(other_channel_all,'all')
-        grid.other_channel = other_channel_all;
-    end
-    
-    %Assign y:
+% Check if grid is finished
+finished = all(data{1, 1}(:, 1),'all');
+
+if finished
     grid.y = y_all;
-
-else  %grid is not finished, take off the any unfinished fast scan line
-    grid.I_all = I_all;
-    grid.I = grid.I_all(:, 1:max(y_coordinates)-1 ,:);
-
-    if any(lock_in_all,'all')
-        grid.lock_in_all = lock_in_all;
-        grid.lock_in = grid.lock_in_all(:, 1:max(y_coordinates)-1, :);
-    end
-
-    if any(I_backward_all,'all')
-        grid.I_backward_all = I_backward_all;
-        grid.I_backward = grid.I_backward_all(:, 1:max(y_coordinates)-1, :);
-    end
-
-    if any(z_all,'all')
-        grid.z_all = z_all;
-        grid.z = grid.z_all(:, 1:max(y_coordinates)-1);
-        %Convert from m to nm
-        grid.z_all = grid.z_all .* 1e9;
-        grid.z = grid.z .* 1e9;
-    end
-    
-    if any(z_backward_all,'all')
-        grid.z_backward_all = z_backward_all;
-        grid.z_backward = grid.z_backward_all(:, 1:max(y_coordinates)-1);
-        %Convert from m to nm
-        grid.z_backward_all = grid.z_backward_all .* 1e9;
-        grid.z_backward = grid.z_backward .* 1e9;
-    end
-
-    if any(other_channel_all,'all')
-        grid.other_channel_all = other_channel_all;
-        grid.other_channel = grid.other_channel_all(:, 1:max(y_coordinates)-1, :);
-    end
-
-    %Assign y:
+else
     grid.y_all = y_all;
     grid.y = grid.y_all(1:max(y_coordinates)-1);
+end
 
+% Extract out the channels
+for channel = 1:number_channels
+    if channelSelection(channel).selected
+        fieldName = channelSelection(channel).fieldName;
+        gridDataAll = zeros(number_x_points, number_y_points, number_bias_points);
+
+        for x = 1:number_x_points
+            for y = 1:number_y_points
+                gridDataAll(x,y,:) = data{x,y}(:,channel);
+            end
+        end
+
+        if finished
+            grid.(fieldName) = gridDataAll;
+        else
+            grid.(fieldName + "_all") = gridDataAll;
+            grid.(fieldName) = gridDataAll(:, 1:max(y_coordinates)-1, :);
+        end
+    end
 end
 
 end

--- a/functions/loading/load_grid_Nanonis.m
+++ b/functions/loading/load_grid_Nanonis.m
@@ -108,7 +108,9 @@ for channel = 1:number_channels
 
         for x = 1:number_x_points
             for y = 1:number_y_points
-                gridDataAll(x,y,:) = data{x,y}(:,channel);
+                if ~isempty(data{x,y})
+                    gridDataAll(x,y,:) = data{x,y}(:,channel);
+                end
             end
         end
 

--- a/functions/loading/load_grid_Nanonis.m
+++ b/functions/loading/load_grid_Nanonis.m
@@ -88,10 +88,10 @@ channelSelection = selectChannels(defaultChannelSelection);
 
 % This section is to determine if we have a partial image and remove 0 values if so. 
 % Note this wasn't necessary for x or V since they're always full
-[~,y_coordinates] = find(all(data{1, 1}(3, 1))); %pixels where there are spectra
+[~,y_coordinates] = find(~cellfun(@isempty, data)); %pixels where there are spectra
 
 % Check if grid is finished
-finished = all(data{1, 1}(:, 1),'all');
+finished = ~any(cellfun(@isempty, data), "all");
 
 if finished
     grid.y = y_all;

--- a/functions/loading/load_spectrum_Nanonis.m
+++ b/functions/loading/load_spectrum_Nanonis.m
@@ -1,5 +1,6 @@
 function spectrum = load_spectrum_Nanonis(folder,spectrumFileName)
 %Wrapper load function for point spectrum '.dat' files
+%   V.K. - 2024, J.T. - 2026
 %   Uses specLoad.m function, processes the data into a structure 
 % Input: 
 %   folder: string of folder containing data
@@ -21,22 +22,50 @@ end
 spectrum.header = header;
 spectrum.header.channels = channels;
 
-%Get the channels from the data: 
+% Create array of default selected channels
 number_channels = size(data,1);
+defaultChannelSelection(number_channels) = struct('channelName', [], 'fieldName', [], 'selected', []);
+
 for channel = 1:number_channels
-    if spectrum.header.channels{channel} == "Current (A)"
-        spectrum.I = data(channel,:);
-    elseif spectrum.header.channels{channel} == "Bias calc (V)"
-        spectrum.V = data(channel,:);
-    elseif spectrum.header.channels{channel} == "LI Demod 1 X (A)"
-        spectrum.lock_in_x = data(channel,:);
-    elseif spectrum.header.channels{channel} == "LI Demod 1 Y (A)"
-        spectrum.lock_in_y = data(channel,:);
-    else
-        disp(strcat("Not saving channel ", spectrum.header.channels{channel}));
+    switch channels{channel}
+        case "Current (A)"
+            fieldName = "I";
+            selected = true;
+        case "Current [bwd] (A)"
+            fieldName = "I_backward";
+            selected = true;
+        case "Bias calc (V)"
+            fieldName = "V";
+            selected = true;
+        case "Bias calc [bwd] (V)"
+            fieldName = "V_backward";
+            selected = true;
+        case "LI Demod 1 X (A)"
+            fieldName = "lock_in_x";
+            selected = true;
+        case "LI Demod 1 Y (A)"
+            fieldName = "lock_in_y";
+            selected = true;
+        otherwise
+            fieldName = "";
+            selected = false;
     end
+
+    defaultChannelSelection(channel).channelName = channels{channel};
+    defaultChannelSelection(channel).fieldName = fieldName;
+    defaultChannelSelection(channel).selected = selected;
 end
 
+% Prompt user to select channels to load
+channelSelection = selectChannels(defaultChannelSelection);
+
+%Get the selected channels from the data:
+for channel = 1:number_channels
+    if channelSelection(channel).selected
+        fieldName = channelSelection(channel).fieldName;
+        spectrum.(fieldName) = data(channel,:);
+    end
+end
 
 end
 

--- a/functions/loading/load_topo_Nanonis.m
+++ b/functions/loading/load_topo_Nanonis.m
@@ -1,6 +1,6 @@
 function topo = load_topo_Nanonis(folder, topoFileName)
 %Wrapper function for loading topos from Nanonis
-%   V.K. - 2024
+%   V.K. - 2024, J.T. - 2026
 %   Uses the Nanonis-made loadsxm.m function, processes the data into a structure 
 %   Known possible channels: 'Z', 'Current', and 'LI_D1_X_1_omega'.
 %   One extra channel of unknown name will be saved as 'other_channel'.
@@ -54,107 +54,80 @@ topo.y_position = header.scan_offset(2);
 channels = topo.header.data_info{:,'Name'};
 number_channels = height(topo.header.data_info);
 
+% Create array of default selected channels
+defaultChannelSelection(number_channels) = struct('channelName', [], 'fieldName', [], 'selected', []);
+
+for channel = 1:number_channels
+    switch channels{channel}
+        case "Z"
+            fieldName = "z";
+            selected = true;
+        case "Current"
+            fieldName = "I";
+            selected = true;
+        case "LI_D1_X_1_omega"
+            fieldName = "lock_in";
+            selected = true;
+        otherwise
+            fieldName = "";
+            selected = false;
+    end
+
+    defaultChannelSelection(channel).channelName = channels{channel};
+    defaultChannelSelection(channel).fieldName = fieldName;
+    defaultChannelSelection(channel).selected = selected;
+end
+
+% Prompt user to select channels to load
+channelSelection = selectChannels(defaultChannelSelection);
+
 % Reshape the raw data by channel and direction. Assumption is that both
 % directions are taken, and so there is 2 images per channel
 data = reshape(raw_data,[number_x_points,number_y_points,number_channels * 2]);
 
 %This section is to determine if we have a partial image and remove NaN
 %values if so. Note that this wasn't necessary for x since it's always full
+% find y pixels where there is data
+[~, y_coordinates] = find(~isnan(data(:,:,1)));
 
-%find y pixels where there is data
-for channel = 1:number_channels
-    if channels(channel) == "Z"
-        z_all = data(:,:,channel);
-    end
-end
-[~, y_coordinates] = find(~isnan(z_all));
+% Check if topo is unfinished
+unfinished = any(isnan(data(:,:,1)), 'all');
 
-
-%first check if the topo is finished 
-if ~any(isnan(z_all),'all') %we have a full topo
-    topo.y = y_all;
-    % Extract out the channels
-    for channel = 1:number_channels
-        if channels(channel) == "Z"
-            topo.z = data(:,:,2*channel-1);
-            topo.z_backward = data(:,:,2*channel);
-            %Apply orientation transformation
-            [topo.z, topo.z_backward] = sxmPermute(topo.z, topo.z_backward, topo.header.scan_dir);
-
-        elseif channels(channel) == "Current"
-            topo.I = data(:,:,2*channel-1);
-            topo.I_backward = data(:,:,2*channel);
-            %Apply orientation transformation
-            [topo.I, topo.I_backward] = sxmPermute(topo.I, topo.I_backward, topo.header.scan_dir);
-
-        elseif channels(channel) == "LI_D1_X_1_omega"
-            topo.lock_in = data(:,:,2*channel-1);
-            topo.lock_in_backward = data(:,:,2*channel);
-            %Apply orientation transformation
-            [topo.lock_in, topo.lock_in_backward] = sxmPermute(topo.lock_in, topo.lock_in_backward, topo.header.scan_dir);
-
-        else
-            topo.other_channel = data(:,:,2*channel-1);
-            topo.other_channel_backward = data(:,:,2*channel);
-            %Apply orientation transformation
-            [topo.other_channel, topo.other_channel_backward] = sxmPermute(topo.other_channel, topo.other_channel_backward, topo.header.scan_dir);
-
-        end
-    end
-
-else % we have an unfinished topo
+if unfinished
     topo.y_all = y_all;
     topo.y = topo.y_all(1:max(y_coordinates)-1);
+else
+    topo.y = y_all;
+end
 
-    %Extract out the channels
-    for channel = 1:number_channels
-        if channels(channel) == "Z"
-            topo.z_all = data(:,:,2*channel-1);
-            topo.z = topo.z_all(:, 1:max(y_coordinates)-1);
+% Extract out the channels
+for channel = 1:number_channels
+    if channelSelection(channel).selected
+        fieldName = channelSelection(channel).fieldName;
+        channelDataAll = data(:, :, 2*channel-1);
+        channelDataBackwardAll = data(:, :, 2*channel);
 
-            topo.z_backward_all = data(:,:,2*channel);
-            topo.z_backward = topo.z_backward_all(:, 1:max(y_coordinates)-1);
-
-            %Apply orientation transformation
-            [topo.z_all, topo.z_backward_all] = sxmPermute(topo.z_all, topo.z_backward_all, topo.header.scan_dir);
-            [topo.z, topo.z_backward] = sxmPermute(topo.z, topo.z_backward, topo.header.scan_dir);
-
-        elseif channels(channel) == "Current"
-            topo.I_all = data(:,:,2*channel-1);
-            topo.I = topo.I_all(:, 1:max(y_coordinates)-1);
-
-            topo.I_backward_all = data(:,:,2*channel);
-            topo.I_backward = topo.I_backward_all(:, 1:max(y_coordinates)-1);
+        if unfinished
+            channelData = channelDataAll(:, 1:max(y_coordinates)-1);
+            channelDataBackward = channelDataBackwardAll(:, 1:max(y_coordinates)-1);
 
             %Apply orientation transformation
-            [topo.I_all, topo.I_backward_all] = sxmPermute(topo.I_all, topo.I_backward_all, topo.header.scan_dir);
-            [topo.I, topo.I_backward] = sxmPermute(topo.I, topo.I_backward, topo.header.scan_dir);
+            [channelData, channelDataBackward] = sxmPermute(channelData, channelDataBackward, topo.header.scan_dir);
+            [channelDataAll, channelDataBackwardAll] = sxmPermute(channelDataAll, channelDataBackwardAll, topo.header.scan_dir);
 
-        elseif channels(channel) == "LI_D1_X_1_omega"
-            topo.lock_in_all = data(:,:,2*channel-1);
-            topo.lock_in = topo.lock_in_all(:, 1:max(y_coordinates)-1);
-
-            topo.lock_in_backward_all = data(:,:,2*channel);
-            topo.lock_in_backward = topo.lock_in_backward_all(:, 1:max(y_coordinates)-1);
-
-            %Apply orientation transformation
-            [topo.lock_in_all, topo.lock_in_backward_all] = sxmPermute(topo.lock_in_all, topo.lock_in_backward_all, topo.header.scan_dir);
-            [topo.lock_in, topo.lock_in_backward] = sxmPermute(topo.lock_in, topo.lock_in_backward, topo.header.scan_dir);
-
+            topo.(fieldName) = channelData;
+            topo.(fieldName + "_backward") = channelDataBackward;
+            topo.(fieldName + "_all") = channelDataAll;
+            topo.(fieldName + "_backward_all") = channelDataBackwardAll;
         else
-            topo.other_channel_all = data(:,:,2*channel-1);
-            topo.other_channel = topo.other_channel_all(:, 1:max(y_coordinates)-1);
-
-            topo.other_channel_backward_all = data(:,:,2*channel);
-            topo.other_channel_backward = topo.other_channel_backward_all(:, 1:max(y_coordinates)-1);
-
             %Apply orientation transformation
-            [topo.other_channel_all, topo.other_channel_backward_all] = sxmPermute(topo.other_channel_all, topo.other_channel_backward_all, topo.header.scan_dir);
-            [topo.other_channel, topo.other_channel_backward] = sxmPermute(topo.other_channel, topo.other_channel_backward, topo.header.scan_dir);
+            [channelDataAll, channelDataBackwardAll] = sxmPermute(channelDataAll, channelDataBackwardAll, topo.header.scan_dir);
+
+            topo.(fieldName) = channelDataAll;
+            topo.(fieldName + "_backward") = channelDataBackwardAll;
         end
     end
 end
-
 
 end
 

--- a/functions/loading/selectChannels.m
+++ b/functions/loading/selectChannels.m
@@ -1,0 +1,104 @@
+function channelSelection = selectChannels(defaultChannelSelection)
+% Prompt user to select channels to load from a list of available channels
+%
+% Both input and output are struct arrays that
+% contain all channels present in the raw data file along with user defined
+% field names. They contain the following fields:
+%   channelName (string): name of channel from data file header
+%   fieldName (string): name of corresponding field that will be added to the data struct
+%   selected (logical): indicates whether channel is selected
+% The order of channels should be the same as in the data file.
+%
+% The caller can set fieldName and selected in the input to control the
+% default behaviour of the channel selector. If fieldName is empty, a field
+% name will be created from channelName.
+%
+% The user is given the option to modify fieldName and selected in for each
+% channel in through the command line interface. The user's choices are
+% then returned to the caller for processing.
+%
+% J. Townsend, 2026
+
+arguments
+    defaultChannelSelection (1,:) struct {mustBeNonempty}
+end
+
+channelSelection = defaultChannelSelection;
+numChannels = numel(channelSelection);
+
+% If there is no default field name, construct an appropriate one from the channel name
+for i = 1:numChannels
+    if channelSelection(i).fieldName == ""
+        fieldName = channelSelection(i).channelName;
+        fieldName = strrep(fieldName, " ", "_");
+        fieldName = regexprep(fieldName, "(.*", "");
+        fieldName = strip(fieldName, "right", "_");
+        fieldName = replace(fieldName, "[bwd]", "backward");
+        fieldName = lower(fieldName);
+        channelSelection(i).fieldName = fieldName;
+    end
+end
+
+% Continue showing the available/selected channels to the user and allowing
+% them to make changes until they indicate that they are finished
+finished = false;
+
+while ~finished
+    disp("Please select the data channels you would like to load:");
+
+    % Display all selected/available channels and field names
+    for i = 1:numChannels
+        displayStr = string(i) + ":  " + channelSelection(i).fieldName + "  [ " + channelSelection(i).channelName + " ]";
+        if channelSelection(i).selected
+            displayStr = "[✓]  " + displayStr;
+        else
+            displayStr = "[ ]  " + displayStr;
+        end
+        disp(displayStr);
+    end
+
+    % Prompt user to select/deselect/rename channels
+    disp("Type # to select/deselect a channel, or type # <name> to select and rename a channel.")
+    disp("Type 0 if you are happy with your selection.")
+
+    inputStr = input("> ", "s");
+
+    % Extract the channel index and field name (if present) from the user's input
+    if contains(inputStr, " ")
+        channelIndex = str2double(extractBefore(inputStr, " "));
+        fieldName = extractAfter(inputStr, " ");
+    else
+        channelIndex = str2double(inputStr);
+        fieldName = "";
+    end
+
+    if channelIndex == 0
+        if fieldName == ""
+            % Exit loop when user gives "0" command
+            finished = true;
+        else
+            disp("Invalid command.");
+        end
+    elseif channelIndex > 0 && channelIndex <= numChannels
+        if fieldName == ""
+            % If user entered a channel number with no text, toggle between selected/deselected
+            channelSelection(channelIndex).selected = ~channelSelection(channelIndex).selected;
+        else
+            % Otherwise, select and rename the channel
+            % Filter out forbidden characters from field name
+            fieldName = regexprep(fieldName,"[^\w\s]","");
+            fieldName = erase(fieldName, "");
+            if strlength(fieldName) < 65
+                channelSelection(channelIndex).selected = true;
+                channelSelection(channelIndex).fieldName = fieldName;
+            else
+                disp("Name exceeds limit of 64 characters.");
+            end
+        end
+    else
+        disp("Invalid channel index.");
+    end
+
+end
+
+end


### PR DESCRIPTION
Added ability to freely select and rename channels when loading Nanonis topos, grids, and spectra for 4-probe compatibility. The old behaviour is still available as the default channel selection.

<img width="632" height="141" alt="image" src="https://github.com/user-attachments/assets/ac3b8e5a-080b-4284-a2c8-c788c3103fd5" />
